### PR TITLE
DL-2035 AWRS S4L fix

### DIFF
--- a/app/connectors/TaxEnrolmentsConnector.scala
+++ b/app/connectors/TaxEnrolmentsConnector.scala
@@ -164,7 +164,7 @@ trait TaxEnrolmentsConnector extends ServicesConfig with LoggingUtils {
             audit(transactionName = auditSubscribeTxName, detail = auditMap, eventType = eventTypeSuccess)
             true
           case status =>
-            warn(s"[TaxEnrolmentsConnector][API10 De-Enrolment - $businessName, $awrsRef, $status ] - ${response.body} ")
+            warn(s"[TaxEnrolmentsConnector][API10 De-Enrolment - $businessName, $status ] - ${response.body} ")
             metrics.incrementFailedCounter(ApiType.API10DeEnrolment)
             audit(transactionName = auditSubscribeTxName, detail = auditMap ++ Map("Business Name" -> businessName,
               "AWRS Ref" -> awrsRef,

--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -58,7 +58,7 @@ trait IndexController extends AwrsController {
               businessPartnerDetails <- save4LaterService.mainStore.fetchBusinessCustomerDetails(ar)
               subscriptionStatus <- api9.getSubscriptionStatusFromCache
               awrsDataMap <- save4LaterService.mainStore.fetchAll(ar)
-              applicationChangeFlag <- applicationService.hasAPI5ApplicationChanged(AccountUtils.getUtr(ar), ar)
+              applicationChangeFlag <- applicationService.hasAPI5ApplicationChanged(ar)
               sectionStatus <- indexService.getStatus(awrsDataMap, businessType, ar)
             } yield {
               val allSectionCompletedFlag = indexService.showContinueButton(sectionStatus)

--- a/app/controllers/WithdrawalController.scala
+++ b/app/controllers/WithdrawalController.scala
@@ -104,7 +104,7 @@ trait WithdrawalController extends AwrsController with LoggingUtils {
           withdrawalDetails.confirmation match {
             case Some("Yes") =>
               lazy val deEnrol = () => {
-                val awrsRef = AccountUtils.getUtr(ar)
+                val awrsRef = AccountUtils.getS4LCacheID(ar.enrolments)
                 val businessName = getBusinessName.fold("")(x => x)
                 val businessType = getBusinessType.fold("")(x => x)
                 deEnrolService.deEnrolAWRS(awrsRef, businessName, businessType)

--- a/app/controllers/util/UnSubmittedBannerUtil.scala
+++ b/app/controllers/util/UnSubmittedBannerUtil.scala
@@ -52,7 +52,7 @@ trait UnSubmittedBannerUtil {
                               (implicit request: Request[AnyContent], hc: HeaderCarrier, ec: ExecutionContext): Future[Option[UnSubmittedChangesBannerParam]] = {
     if (AccountUtils.hasAwrs(authRetrievals.enrolments)) {
       val businessType = request.session.get(AwrsSessionKeys.sessionBusinessType).fold("")(x => x)
-      applicationService.hasAPI5ApplicationChanged(AccountUtils.getUtr(authRetrievals), authRetrievals).flatMap {
+      applicationService.hasAPI5ApplicationChanged(authRetrievals).flatMap {
         case false => Future.successful(None)
         case true =>
           for {

--- a/app/models/FormModels.scala
+++ b/app/models/FormModels.scala
@@ -634,7 +634,7 @@ object TradingActivity {
   val Other = "99"
   val Delimiter = " "
 
-  implicit val writer = new Writes[TradingActivity] {
+  implicit lazy val writer = new Writes[TradingActivity] {
 
     // remove the Producer and Broker wholesaler codes if required as they will be sent via the 'Other' field from now on
     // and add the 'Other' code to the wholesaler type if either Producer or Broker are selected
@@ -670,7 +670,7 @@ object TradingActivity {
         .++(tradingActivity.exportLocation.fold(Json.obj())(x => Json.obj("exportLocation" -> x)))
   }
 
-  implicit val reader = new Reads[TradingActivity] {
+  implicit lazy val reader = new Reads[TradingActivity] {
 
     // remove the 'Other' wholesaler type if it only contained Producer and Broker so it is not selected on the screen
     // add the Producer and Broker wholesaler codes if required so they are selected on the screen

--- a/app/services/KeyStoreService.scala
+++ b/app/services/KeyStoreService.scala
@@ -126,7 +126,7 @@ trait KeyStoreService {
 
   @inline def saveSave4LaterBackup(save4LaterConnector: Save4LaterConnector, authRetrievals: StandardAuthRetrievals)
                                   (implicit hc: HeaderCarrier): Future[CacheMap] = {
-    save4LaterConnector.fetchAll(AccountUtils.getUtr(authRetrievals)).flatMap {
+    save4LaterConnector.fetchAll(AccountUtils.getS4LCacheID(authRetrievals.enrolments)).flatMap {
       case Some(cacheMap) => keyStoreConnector.saveDataToKeystore(save4LaterBackupName, cacheMap.copyOfSave4Later)
       case None => throw new RuntimeException("Backup save4Later to keystore failed, not data found in save4later")
     }

--- a/app/services/Save4LaterService.scala
+++ b/app/services/Save4LaterService.scala
@@ -32,17 +32,17 @@ trait Save4LaterUtil {
   val save4LaterConnector: Save4LaterConnector
 
   @inline def fetchData4Later[T](formId: String, authRetrievals: StandardAuthRetrievals)(implicit hc: HeaderCarrier, formats: play.api.libs.json.Format[T]): Future[Option[T]] = {
-    save4LaterConnector.fetchData4Later[T](AccountUtils.getUtr(authRetrievals), formId)
+    save4LaterConnector.fetchData4Later[T](AccountUtils.getS4LCacheID(authRetrievals.enrolments), formId)
   }
 
   @inline def saveData4Later[T](formId: String, data: T, authRetrievals: StandardAuthRetrievals)(implicit hc: HeaderCarrier, formats: play.api.libs.json.Format[T]): Future[T] =
-    save4LaterConnector.saveData4Later[T](AccountUtils.getUtr(authRetrievals), formId, data) map (_.get)
+    save4LaterConnector.saveData4Later[T](AccountUtils.getS4LCacheID(authRetrievals.enrolments), formId, data) map (_.get)
 
   @inline def fetchAll(authRetrievals: StandardAuthRetrievals)(implicit hc: HeaderCarrier): Future[Option[CacheMap]] =
-    save4LaterConnector.fetchAll(AccountUtils.getUtr(authRetrievals))
+    save4LaterConnector.fetchAll(AccountUtils.getS4LCacheID(authRetrievals.enrolments))
 
   @inline def removeAll(authRetrievals: StandardAuthRetrievals)(implicit hc: HeaderCarrier): Future[HttpResponse] =
-    save4LaterConnector.removeAll(AccountUtils.getUtr(authRetrievals))
+    save4LaterConnector.removeAll(AccountUtils.getS4LCacheID(authRetrievals.enrolments))
 }
 
 trait Save4LaterService {

--- a/app/utils/AccountUtils.scala
+++ b/app/utils/AccountUtils.scala
@@ -17,22 +17,25 @@
 package utils
 
 import controllers.auth.StandardAuthRetrievals
-import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
-import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolment, EnrolmentIdentifier}
+import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolment}
 
 object AccountUtils extends AccountUtils
 
 trait AccountUtils extends LoggingUtils {
 
-  def getUtr(authRetrievals: StandardAuthRetrievals): String = {
-    val firstUtr = (authRetrievals.enrolments flatMap { enrolment =>
+  def getS4LCacheID(enrolments: Set[Enrolment]): String = {
+    val firstUtr = (enrolments flatMap { enrolment =>
       enrolment.identifiers.filter(_.key.toLowerCase == "utr")
     }).headOption
 
-    (firstUtr, authRetrievals.affinityGroup) match {
-      case (Some(utr), _) => utr.value.toString
-      case (_, Some(org)) if org == AffinityGroup.Organisation => org.toString
-      case _ => throw new RuntimeException("[getUtr] No UTR found")
+    val awrsRefNo = (enrolments flatMap { enrolment =>
+      enrolment.identifiers.filter(_.key.toLowerCase == "awrsrefnumber")
+    }).headOption
+
+    (firstUtr, awrsRefNo) match {
+      case (Some(utr), _)   => utr.value.toString
+      case (_, Some(refno)) => refno.value.toString
+      case _ => throw new RuntimeException("[getS4LCacheID] No UTR found")
     }
   }
 

--- a/test/services/ApplicationServiceTest.scala
+++ b/test/services/ApplicationServiceTest.scala
@@ -875,55 +875,55 @@ class ApplicationServiceTest extends AwrsUnitTestTraits
       "return valid Section object when legal entity is LTD" in {
         setupMockSave4LaterServiceWithOnly(fetchAll = cachedData())
         val expectedSection = Sections(corporateBodyBusinessDetails = true, businessDirectors = true)
-        val outputSection = await(TestApplicationService.getSections("cacheID", TestUtil.defaultAuthRetrieval))
+        val outputSection = await(TestApplicationService.getSections(TestUtil.defaultAuthRetrieval))
         outputSection shouldBe expectedSection
       }
 
       "return valid Section object when legal entity is SOP" in {
         setupMockSave4LaterServiceWithOnly(fetchAll = cachedData(dynamicLegalEntity("SOP")))
         val expectedSection = Sections(soleTraderBusinessDetails = true)
-        val outputSection = await(TestApplicationService.getSections("cacheID", TestUtil.defaultAuthRetrieval))
+        val outputSection = await(TestApplicationService.getSections(TestUtil.defaultAuthRetrieval))
         outputSection shouldBe expectedSection
       }
 
       "return valid Section object when legal entity is Partnership" in {
         setupMockSave4LaterServiceWithOnly(fetchAll = cachedData(dynamicLegalEntity("Partnership")))
         val expectedSection = Sections(partnershipBusinessDetails = true, partnership = true)
-        val outputSection = await(TestApplicationService.getSections("cacheID", TestUtil.defaultAuthRetrieval))
+        val outputSection = await(TestApplicationService.getSections(TestUtil.defaultAuthRetrieval))
         outputSection shouldBe expectedSection
       }
 
       "return valid Section object when legal entity is LP" in {
         setupMockSave4LaterServiceWithOnly(fetchAll = cachedData(dynamicLegalEntity("LP")))
         val expectedSection = Sections(llpBusinessDetails = true, partnership = true)
-        val outputSection = await(TestApplicationService.getSections("cacheID", TestUtil.defaultAuthRetrieval))
+        val outputSection = await(TestApplicationService.getSections(TestUtil.defaultAuthRetrieval))
         outputSection shouldBe expectedSection
       }
 
       "return valid Section object when legal entity is LLP" in {
         setupMockSave4LaterServiceWithOnly(fetchAll = cachedData(dynamicLegalEntity("LLP")))
         val expectedSection = Sections(llpBusinessDetails = true, partnership = true)
-        val outputSection = await(TestApplicationService.getSections("cacheID", TestUtil.defaultAuthRetrieval))
+        val outputSection = await(TestApplicationService.getSections(TestUtil.defaultAuthRetrieval))
         outputSection shouldBe expectedSection
       }
 
       "return valid Section object when legal entity is LTD_GRP" in {
         setupMockSave4LaterServiceWithOnly(fetchAll = cachedData(dynamicLegalEntity("LTD_GRP")))
         val expectedSection = Sections(groupRepBusinessDetails = true, groupMemberDetails = true, businessDirectors = true)
-        val outputSection = await(TestApplicationService.getSections("cacheID", TestUtil.defaultAuthRetrieval))
+        val outputSection = await(TestApplicationService.getSections(TestUtil.defaultAuthRetrieval))
         outputSection shouldBe expectedSection
       }
 
       "return valid Section object when legal entity is LLP_GRP" in {
         setupMockSave4LaterServiceWithOnly(fetchAll = cachedData(dynamicLegalEntity("LLP_GRP")))
         val expectedSection = Sections(groupRepBusinessDetails = true, groupMemberDetails = true, partnership = true)
-        val outputSection = await(TestApplicationService.getSections("cacheID", TestUtil.defaultAuthRetrieval))
+        val outputSection = await(TestApplicationService.getSections(TestUtil.defaultAuthRetrieval))
         outputSection shouldBe expectedSection
       }
 
       "return exception when legal entity is invalid" in {
         setupMockSave4LaterServiceWithOnly(fetchAll = cachedData(dynamicLegalEntity("XYZ")))
-        val thrown = the[InvalidStateException] thrownBy await(TestApplicationService.getSections("cacheID", TestUtil.defaultAuthRetrieval))
+        val thrown = the[InvalidStateException] thrownBy await(TestApplicationService.getSections(TestUtil.defaultAuthRetrieval))
         thrown.getMessage shouldBe "Invalid Legal entity"
       }
     }
@@ -1042,14 +1042,14 @@ class ApplicationServiceTest extends AwrsUnitTestTraits
       "return false if no section has changed" in {
         setupMockSave4LaterService(fetchAll = matchingSoleTraderCacheMap)
         setupMockApiSave4LaterService(fetchSubscriptionTypeFrontEnd = soleTraderSubscriptionTypeFrontEnd)
-        val result = TestApplicationService.hasAPI5ApplicationChanged(testUtr, TestUtil.defaultAuthRetrieval)
+        val result = TestApplicationService.hasAPI5ApplicationChanged(TestUtil.defaultAuthRetrieval)
         await(result) shouldBe false
       }
 
       "return true if any section has changed" in {
         setupMockSave4LaterService(fetchAll = matchingSoleTraderCacheMap)
         setupMockApiSave4LaterService(fetchSubscriptionTypeFrontEnd = differentSoleTraderSubscriptionTypeFrontEnd)
-        val result = TestApplicationService.hasAPI5ApplicationChanged(testUtr, TestUtil.defaultAuthRetrieval)
+        val result = TestApplicationService.hasAPI5ApplicationChanged(TestUtil.defaultAuthRetrieval)
         await(result) shouldBe true
       }
     }

--- a/test/services/mocks/MockApplicationService.scala
+++ b/test/services/mocks/MockApplicationService.scala
@@ -38,7 +38,7 @@ trait MockApplicationService extends AwrsUnitTestTraits {
 
   protected final def setupMockApplicationService(hasAPI5ApplicationChanged: Boolean = defaultTrueBoolean,
                                                   getApi5ChangeIndicators: SectionChangeIndicators = defaultSectionChangeIndicators): Unit = {
-    when(mockApplicationService.hasAPI5ApplicationChanged(Matchers.any(),Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(hasAPI5ApplicationChanged))
+    when(mockApplicationService.hasAPI5ApplicationChanged(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(hasAPI5ApplicationChanged))
     when(mockApplicationService.getApi5ChangeIndicators(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(getApi5ChangeIndicators))
   }
 }

--- a/test/utils/AccountUtilsTest.scala
+++ b/test/utils/AccountUtilsTest.scala
@@ -19,29 +19,28 @@ package utils
 import controllers.auth.StandardAuthRetrievals
 import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolment}
 import uk.gov.hmrc.play.test.UnitSpec
-import utils.TestConstants._
 
 class AccountUtilsTest extends UnitSpec {
 
-  "getUtr" should {
-    "Return the user SA utr " in {
-      val utr = AccountUtils.getUtr(StandardAuthRetrievals(TestUtil.defaultSaEnrolmentSet, Some(AffinityGroup.Individual)))
-      utr shouldBe "0123456"
+  "getS4LCacheID" should {
+    "Return the user SA utr" in {
+      val utr = AccountUtils.getS4LCacheID(TestUtil.defaultSaEnrolmentSet)
+      utr shouldBe "123987"
     }
 
     "Return the user CT utr for org" in {
-      val utr = AccountUtils.getUtr(StandardAuthRetrievals(TestUtil.defaultEnrolmentSet, Some(AffinityGroup.Individual)))
+      val utr = AccountUtils.getS4LCacheID(TestUtil.defaultEnrolmentSet)
       utr shouldBe "6543210"
     }
 
-    "Return the org name " in {
-      val orgId = AccountUtils.getUtr(StandardAuthRetrievals(Set(), Some(AffinityGroup.Organisation)))
-      orgId shouldBe "Organisation"
+    "Return the user AWRS-REF-ORG if there is no UTR" in {
+      val utr = AccountUtils.getS4LCacheID(TestUtil.defaultOnlyAwrsOfSet)
+      utr shouldBe "0123456"
     }
 
     "throw exception if no details are found" in {
-      val thrown = the[RuntimeException] thrownBy AccountUtils.getUtr(StandardAuthRetrievals(Set.empty[Enrolment], Some(AffinityGroup.Individual)))
-      thrown.getMessage should include("[getUtr] No UTR found")
+      val thrown = the[RuntimeException] thrownBy AccountUtils.getS4LCacheID(Set.empty[Enrolment])
+      thrown.getMessage should include("[getS4LCacheID] No UTR found")
     }
   }
 

--- a/test/utils/TestUtil.scala
+++ b/test/utils/TestUtil.scala
@@ -827,7 +827,9 @@ object TestUtil {
     Enrolment("IR-CT", Seq(EnrolmentIdentifier("UTR", "6543210")), "activated"), Enrolment("IR-SA", Seq(EnrolmentIdentifier("UTR", "0123456")), "activated"))
 
   val defaultSaEnrolmentSet = Set(Enrolment("HMRC-AWRS-ORG", Seq(EnrolmentIdentifier("AWRSRefNumber", "0123456")), "activated"),
-    Enrolment("IR-SA", Seq(EnrolmentIdentifier("UTR", "0123456")), "activated"))
+    Enrolment("IR-SA", Seq(EnrolmentIdentifier("UTR", "123987")), "activated"))
+
+  val defaultOnlyAwrsOfSet = Set(Enrolment("HMRC-AWRS-ORG", Seq(EnrolmentIdentifier("AWRSRefNumber", "0123456")), "activated"))
 
   val defaultAuthRetrieval = StandardAuthRetrievals(defaultEnrolmentSet, Some(AffinityGroup.Organisation))
 

--- a/test/views/ViewApplicationViewTest.scala
+++ b/test/views/ViewApplicationViewTest.scala
@@ -128,7 +128,7 @@ class ViewApplicationViewTest extends AwrsUnitTestTraits
     def viewSection(sectionName: String, cacheMap: CacheMap, printFriendly: Boolean = false)(test: Future[Result] => Any) = {
       setupMockSave4LaterService(fetchBusinessCustomerDetails = testBusinessCustomerDetails("SOP"), fetchAll = cacheMap)
       setAuthMocks()
-      when(mockApplicationService.hasAPI5ApplicationChanged(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any())) thenReturn Future.successful(false)
+      when(mockApplicationService.hasAPI5ApplicationChanged(Matchers.any())(Matchers.any(), Matchers.any())) thenReturn Future.successful(false)
       val result = TestViewApplicationController.viewSection(sectionName, printFriendly).apply(SessionBuilder.buildRequestWithSession(userId))
       test(result)
     }


### PR DESCRIPTION
# DL-2035 AWRS S4L fix

**Bug fix**

* Bug fix. If the UTR cannot be used as a S4L cache id - the AWRS-Ref-No identifier will be used, which is unique.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
