### PR TITLE
DL-2011 Address not pre-selected plus dependency updates

### DIFF
--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -12,16 +12,16 @@ private object AppDependencies {
   import play.core.PlayVersion
   import play.sbt.PlayImport._
 
-  private val frontendbootstrap = "12.6.0"
+  private val frontendbootstrap = "12.9.0"
   private val domainVersion = "5.6.0-play-25"
-  private val hmrcTestVersion = "3.6.0-play-25"
+  private val hmrcTestVersion = "3.9.0-play-25"
 
   private val urlBuilderVersion = "3.1.0"
-  private val httpCachingClientVersion = "8.2.0"
-  private val playPartialsVersion = "6.7.0-play-25"
+  private val httpCachingClientVersion = "8.4.0-play-25"
+  private val playPartialsVersion = "6.9.0-play-25"
   private val pegDownVersion = "1.6.0"
   private val jSoupVersion = "1.8.3"
-  private val jSonEncryptionVersion = "4.1.0"
+  private val jSonEncryptionVersion = "4.4.0-play-25"
   private val mockitoAllVersion = "1.10.19"
   private val scalaTestPlusPlayVersion = "2.0.1"
 
@@ -35,7 +35,7 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "domain" % domainVersion,
     "uk.gov.hmrc" %% "json-encryption" % jSonEncryptionVersion,
     "com.mohiva" %% "play-html-compressor" % "0.6.3", // used to pretty print html by stripping out all the whitespaces added by the playframework
-    "uk.gov.hmrc" %% "auth-client" % "2.20.0-play-25"
+    "uk.gov.hmrc" %% "auth-client" % "2.22.0-play-25"
   )
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,15 +4,15 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.16.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.19.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.3.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.6.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-settings" % "3.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-settings" % "3.11.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
@@ -20,4 +20,4 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.2")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.17.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.19.0")

--- a/public/javascripts/postcodeLookup.js
+++ b/public/javascripts/postcodeLookup.js
@@ -222,7 +222,6 @@
             $('#result-' + num).addClass('show').focus();
             $(".dropdown-menu").show();
             hideErrorMessage(num);
-            $(".postcode-results-fieldset").find("input").first().prop("checked",true)
         }
     }
 


### PR DESCRIPTION
# DL-2011additional 

**Bug fix** 

Reapplying change whereby address lookup was automatically selecting the first returned address (where multiple addresses are available). Originally defined under story DL-2011 and solution obtained. Same change applied and tested (following clearance of browser history and cache) together with available dependency updates and plugin updates.

Unit tests, acceptance tests all pass successfully.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
