### PR TITLE
DL-2123 Removed NoUpdatesRequired usages from HomeController

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -38,7 +38,6 @@ trait HomeController extends AwrsController with AccountUtils {
 
   val businessCustomerService: BusinessCustomerService
   implicit val save4LaterService: Save4LaterService
-  val modelUpdateService: ModelUpdateService
 
 
   private def awrsIdentifier(implicit user: AuthContext, hc: HeaderCarrier): String = {
@@ -122,15 +121,15 @@ trait HomeController extends AwrsController with AccountUtils {
       case _ => Future.successful(InternalServerError(views.html.awrs_application_too_soon_error(applicationStatus)))
     }
 
-  def startJourney(callerId: Option[String])(implicit user: AuthContext, request: Request[AnyContent]): Future[Result] =
-    modelUpdateService.ensureAllModelsAreUpToDate.flatMap {
-      case true =>
-        AccountUtils.hasAwrs match {
-          case true => api5Journey(callerId)
-          case false => api4Journey(callerId)
-        }
-      case _ => showErrorPage
+  def startJourney(callerId: Option[String])(implicit user: AuthContext, request: Request[AnyContent]): Future[Result] = {
+
+    if (AccountUtils.hasAwrs){
+      api5Journey(callerId)
+    } else {
+      api4Journey(callerId)
     }
+  }
+
 
 }
 
@@ -138,6 +137,5 @@ object HomeController extends HomeController {
   override val authConnector = FrontendAuthConnector
   override val businessCustomerService = BusinessCustomerService
   override val save4LaterService = Save4LaterService
-  /* TODO save4later update for AWRS-1800 to be replaced by NoUpdatesRequired after 28 days*/
-  override val modelUpdateService = NoUpdatesRequired //NoUpdatesRequired
+
 }

--- a/app/services/ModelUpdateService.scala
+++ b/app/services/ModelUpdateService.scala
@@ -30,9 +30,6 @@ trait ModelUpdateService {
   def ensureAllModelsAreUpToDate(implicit user: AuthContext, hc: HeaderCarrier, save4LaterService: Save4LaterService): Future[Boolean]
 }
 
-object NoUpdatesRequired extends ModelUpdateService {
-  override def ensureAllModelsAreUpToDate(implicit user: AuthContext, hc: HeaderCarrier, save4LaterService: Save4LaterService): Future[Boolean] = Future.successful(true)
-}
 
 object UpdateRequired extends ModelUpdateService {
 

--- a/test/controllers/HomeControllerTest.scala
+++ b/test/controllers/HomeControllerTest.scala
@@ -31,8 +31,8 @@ import play.api.libs.json.JsResultException
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import services.BusinessCustomerService
 import services.mocks.MockSave4LaterService
-import services.{BusinessCustomerService, NoUpdatesRequired}
 import utils.AwrsUnitTestTraits
 import utils.TestUtil._
 
@@ -50,7 +50,7 @@ class HomeControllerTest extends AwrsUnitTestTraits
     override val authConnector = mockAuthConnector
     override val businessCustomerService = mockBusinessCustomerService
     override val save4LaterService = TestSave4LaterService
-    override val modelUpdateService = NoUpdatesRequired
+
   }
 
   override def beforeEach(): Unit = {


### PR DESCRIPTION
DL-2123 Removed NoUpdatesRequired usages from HomeController

AWRS-FE's HomeController referred to a dummy update service which simply returned Future.successful, with the old UpdatesRequired code still remaining in the code base making them redundant. In this commit I've removed all usages of this code.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
