### PR TITLE
DL-2036: Removed autocomplete across the app

### DIFF
--- a/app/views/helpers/awrsInputTypeGroupCheckbox.scala.html
+++ b/app/views/helpers/awrsInputTypeGroupCheckbox.scala.html
@@ -95,6 +95,7 @@
             @params.checkboxOptions.map { checkboxOptions =>
                 <label for="@(inputId(checkboxOptions._1))" class="block-label" id="@(inputId(checkboxOptions._1))_label">
                     <input type="checkbox"
+                           autocomplete="off"
                            id="@(inputId(checkboxOptions._1))"
                            @if(params.ariaDescribedBy){
                                 aria-describedby="@{params.ariaDescribedBy}"

--- a/app/views/helpers/awrsInputTypeRadioGroup.scala.html
+++ b/app/views/helpers/awrsInputTypeRadioGroup.scala.html
@@ -150,6 +150,7 @@
                     <label id="@inputId-label" for="@inputId" class="block-label @labelClass @params.field.value.filter(_ == value).map { _ => selected }">
                         @if(!labelAfter)@{addLabelIfSpecified(label, params)}
                         <input type="radio"
+                               autocomplete="off"
                                id="@inputId"
                                @if(params.ariaDescribedBy){
                                     @if(params.ariaDescribedByForYesOptionOnly && (value == "Yes")) {

--- a/app/views/helpers/awrsInputTypeText.scala.html
+++ b/app/views/helpers/awrsInputTypeText.scala.html
@@ -145,6 +145,7 @@
            name="@params.field.name"
            id="@inputId"
            value="@value"
+           autocomplete="off"
            @maxLength
            @dataAttributes
            @required

--- a/app/views/helpers/backLink.scala.html
+++ b/app/views/helpers/backLink.scala.html
@@ -17,13 +17,14 @@
 @import views.view_application.helpers._
 @import views.view_application.helpers.SubViewTemplateHelper._
 
-@(backUrl :String = controllers.routes.IndexController.showLastLocation().toString, alwaysShow: Boolean = false)(implicit viewApplicationType: ViewApplicationType = LinearViewMode,messages: Messages)
-@{
-    (isOneViewMode, alwaysShow) match {
-        case (true, true) =>
-            <p><a id="back" class="back-link print-hidden" href="javascript:history.back()">{Messages("awrs.generic.back")}</a></p>
-        case (false, _) =>
-            <p><a id="back" class="back-link print-hidden" href="javascript:history.back()">{Messages("awrs.generic.back")}</a></p>
-        case _ =>
+@(backUrl: String = controllers.routes.IndexController.showLastLocation().toString, alwaysShow: Boolean = false)(implicit viewApplicationType: ViewApplicationType = LinearViewMode, messages: Messages)
+    @{
+        (isOneViewMode, alwaysShow) match {
+            case (true, false) =>
+            case _ =>
+                <p>
+                    <a id="back" class="back-link print-hidden"
+                    href="javascript:history.back()">{messages("awrs.generic.back")}</a>
+                </p>
+        }
     }
-}

--- a/app/views/helpers/backLinkHelper.scala.html
+++ b/app/views/helpers/backLinkHelper.scala.html
@@ -18,7 +18,6 @@
 @import views.view_application.helpers.SubViewTemplateHelper._
 @import views.view_application.helpers.ViewApplicationType
 
-
 @(params: BackLinkParams)(implicit viewApplicationType: ViewApplicationType, messages: Messages)
 
 @backUrl = @{

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -7,7 +7,6 @@ object FrontendBuild extends Build with MicroService {
   override lazy val appDependencies: Seq[ModuleID] = AppDependencies()
 }
 
-
 private object AppDependencies {
   import play.core.PlayVersion
   import play.sbt.PlayImport._
@@ -16,15 +15,12 @@ private object AppDependencies {
   private val pegdownVersion = "1.6.0"
   private val scalaTestplusPlayVersion = "3.1.3"
 
-
-
-
   val compile = Seq(
     ws,
     "com.typesafe.play" %% "anorm" % "2.5.3",
     "uk.gov.hmrc" %% "url-builder" % "3.3.0-play-26",
     "uk.gov.hmrc" %% "http-caching-client" % "9.0.0-play-26",
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.5.0", // includes the global object and error handling, as well as the FrontendController classes and some common configuration
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.6.0", // includes the global object and error handling, as well as the FrontendController classes and some common configuration
     "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-26", // includes code for retrieving partials, e.g. the Help with this page form
     "uk.gov.hmrc" %% "domain" % "5.6.0-play-26",
     "uk.gov.hmrc" %% "json-encryption" % "4.5.0-play-26",
@@ -46,8 +42,8 @@ private object AppDependencies {
     def apply(): Seq[ModuleID] = new TestDependencies {
       override lazy val test = Seq(
         "org.pegdown" % "pegdown" % "1.6.0" % scope,
-        "org.jsoup" % "jsoup" % "1.12.1" % scope,
-        "org.mockito" % "mockito-core" % "3.2.4" % scope,
+        "org.jsoup" % "jsoup" % "1.13.1" % scope,
+        "org.mockito" % "mockito-core" % "3.3.3" % scope,
         "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestplusPlayVersion % scope
       )
@@ -64,7 +60,7 @@ private object AppDependencies {
         "org.pegdown" % "pegdown" % pegdownVersion % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestplusPlayVersion % scope,
-        "com.github.tomakehurst" % "wiremock-jre8" % "2.26.0" % scope
+        "com.github.tomakehurst" % "wiremock-jre8" % "2.26.3" % scope
       )
     }.test
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
@@ -16,6 +16,6 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-settings" % "4.1.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
DL-2036: Removed autocomplete across the app

**Bug fix**

Removed autocomplete from all input fields to ensure that when the user uses history back in the app they will not see browser-cached autocompleted fields which have not been saved in the backend.

The behaviour between Chrome and Firefox was shown to be inconsistent. Now the app will only populate fields with the data it actually has instead of data which has not been saved yet.

## Checklist

Reviewee (David Thornton)

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date

Reviewer (Paul Anderson)

 - [x]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date