### PR TITLE
DL-2864 Disable xml report plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,3 +55,4 @@ lazy val microservice = Project(appName, file("."))
     resolvers += Resolver.bintrayRepo("hmrc", "releases"),
     resolvers += Resolver.jcenterRepo
   )
+  .disablePlugins(JUnitXmlReportPlugin)


### PR DESCRIPTION
# DL-2864 Disable xml report plugin

**Bug fix**

* Disabled xml report plugin to allow awes-frontend to build

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date