### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -50,10 +50,6 @@ review-details.cache = "business-customer-frontend"
 
 play.filters {
   headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 stats.g.doubleclick.net www.google-analytics.com data:"
-  csrf.header.bypassHeaders {
-    X-Requested-With = "*"
-    Csrf-Token = "nocheck"
-  }
 }
 
 #encryption key for save4later


### PR DESCRIPTION
# PSEC-1051 A large number of configuration files in production contains code which allows the anti-csrf checks to be bypassed:



**Bug fix** (delete as appropriate)

The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051

## Checklist

Jez D

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions

Reviewer (Replace with your name)

 - [ ]  I've confirmed that every effort has been made to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've confirmed appropriate tests has been included with any code added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've confirmed code was added using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date