### PR TITLE
Update title inline with standards pages that error

### DIFF
--- a/app/views/ViewUtils.scala
+++ b/app/views/ViewUtils.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import play.api.data.Form
+import play.api.i18n.Messages
+
+object ViewUtils {
+
+  def errorPrefix(form: Form[_])(implicit messages: Messages): String =
+    if (form.hasErrors || form.hasGlobalErrors) messages("error.browser.title.prefix") else ""
+
+}

--- a/app/views/awrs_additional_premises.scala.html
+++ b/app/views/awrs_additional_premises.scala.html
@@ -23,6 +23,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits._
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
 formWithCSRF: FormWithCSRF,
@@ -66,7 +67,9 @@ govukErrorSummary: GovukErrorSummary)
     }
 }
 
-    @awrsMain(title = messages("awrs.generic.tab.title", businessPremisesIdHeading), pageScripts = Some(pageScripts), userLoggedIn = true) {
+    @awrsMain(
+        title = s"${errorPrefix(businessPremisesForm)} ${messages("awrs.generic.tab.title", businessPremisesIdHeading)}",
+        pageScripts = Some(pageScripts), userLoggedIn = true) {
         <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/dropdowns-enhancement.min.css")'/>
 
                 @backLinkHelper(BackLinkParams(

--- a/app/views/awrs_already_starting_trading.scala.html
+++ b/app/views/awrs_already_starting_trading.scala.html
@@ -23,6 +23,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -40,7 +41,9 @@
     }
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.generic.have_you_already")), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(confirmationForm)} ${messages("awrs.generic.tab.title", messages("awrs.generic.have_you_already"))}",
+    userLoggedIn = true) {
 
 @backLink(controllers.routes.TradingLegislationDateController.showBusinessDetails().url)
 

--- a/app/views/awrs_application_declaration.scala.html
+++ b/app/views/awrs_application_declaration.scala.html
@@ -20,6 +20,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -38,7 +39,9 @@
     }
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.application_declaration.heading")), userLoggedIn = true){
+@awrsMain(
+    title = s"${errorPrefix(applicationDeclarationForm)} ${messages("awrs.generic.tab.title", messages("awrs.application_declaration.heading"))}",
+    userLoggedIn = true){
 
 @if(applicationDeclarationForm.errors.nonEmpty) {
     @govukErrorSummary(ErrorSummary().withFormErrorsAsHtml(applicationDeclarationForm))

--- a/app/views/awrs_business_contacts.scala.html
+++ b/app/views/awrs_business_contacts.scala.html
@@ -25,6 +25,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -98,7 +99,9 @@
 }
 
 
-@awrsMain(title = messages("awrs.generic.tab.title", businessTypeHeading), pageScripts = Some(pageScripts), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(businessContactsForm)} ${messages("awrs.generic.tab.title", businessTypeHeading)}",
+    pageScripts = Some(pageScripts), userLoggedIn = true) {
     <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/dropdowns-enhancement.min.css")'/>
 
             @backLinkHelper(BackLinkParams(

--- a/app/views/awrs_business_directors.scala.html
+++ b/app/views/awrs_business_directors.scala.html
@@ -23,6 +23,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
 @import uk.gov.hmrc.govukfrontend.views.Implicits._
+@import views.ViewUtils._
 
 @this(formWithCSRF: FormWithCSRF,
         awrsMain: main,
@@ -240,7 +241,9 @@
 
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", h1text), userLoggedIn = true){
+@awrsMain(
+    title = s"${errorPrefix(businessDirectorsForm)} ${messages("awrs.generic.tab.title", h1text)}",
+    userLoggedIn = true){
 
         @backLinkHelper(BackLinkParams(
             sectionName = businessDirectorsName

--- a/app/views/awrs_business_registration_details.scala.html
+++ b/app/views/awrs_business_registration_details.scala.html
@@ -22,6 +22,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -61,7 +62,9 @@
     }
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", businessTypeHeading), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(businessRegistrationDetailsForm)} ${messages("awrs.generic.tab.title", businessTypeHeading)}",
+    userLoggedIn = true) {
 
             @backLinkHelper(BackLinkParams(
                 sectionName = businessRegistrationDetailsName

--- a/app/views/awrs_business_type.scala.html
+++ b/app/views/awrs_business_type.scala.html
@@ -21,6 +21,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -32,7 +33,9 @@
 
 @implicitFormInstance = @{ Some(businessTypeForm) }
 
-@awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.business_verification.heading")), nameBusiness = Some(businessName), userLoggedIn = true){
+@awrsMain(
+    title = s"${errorPrefix(businessTypeForm)} ${messages("awrs.generic.tab.title", messages("awrs.business_verification.heading"))}",
+    nameBusiness = Some(businessName), userLoggedIn = true){
 
     @if(businessTypeForm.errors.nonEmpty) {
         @govukErrorSummary(ErrorSummary().withFormErrorsAsText(businessTypeForm))

--- a/app/views/awrs_de_registration.scala.html
+++ b/app/views/awrs_de_registration.scala.html
@@ -21,6 +21,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichDateInput
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -47,7 +48,9 @@
         )
     }
 
-@awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.de_registration.heading")), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(deRegistrationForm)} ${messages("awrs.generic.tab.title", messages("awrs.de_registration.heading"))}",
+    userLoggedIn = true) {
 
 @backLink(backUrl = controllers.routes.DeRegistrationController.showReason.toString)
 

--- a/app/views/awrs_de_registration_confirm.scala.html
+++ b/app/views/awrs_de_registration_confirm.scala.html
@@ -22,6 +22,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
 @import views.html.helpers._
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -40,7 +41,9 @@
     ))
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.de_registration.confirmation_heading")), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(confirmationForm)} ${messages("awrs.generic.tab.title", messages("awrs.de_registration.confirmation_heading"))}",
+    userLoggedIn = true) {
 
 @backLink(backUrl = controllers.routes.DeRegistrationController.showDate.toString)
 

--- a/app/views/awrs_de_registration_reason.scala.html
+++ b/app/views/awrs_de_registration_reason.scala.html
@@ -23,6 +23,7 @@
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
 @import forms.DeRegistrationReasonForm._
 @import views.html.helpers._
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -45,7 +46,9 @@
     )
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.de_registration_reason.page_heading")), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(deRegistrationReason)} ${messages("awrs.generic.tab.title", messages("awrs.de_registration_reason.page_heading"))}",
+    userLoggedIn = true) {
 
     @backLink(backUrl = controllers.routes.IndexController.showIndex.toString)
     @if(deRegistrationReason.errors.nonEmpty) {

--- a/app/views/awrs_group_declaration.scala.html
+++ b/app/views/awrs_group_declaration.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -32,7 +33,9 @@
     Some(groupDeclarationForm)
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.group_declaration.heading")), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(groupDeclarationForm)} ${messages("awrs.generic.tab.title", messages("awrs.group_declaration.heading"))}",
+    userLoggedIn = true) {
 
             @if(groupDeclarationForm.errors.nonEmpty) {
                 @govukErrorSummary(ErrorSummary().withFormErrorsAsText(groupDeclarationForm))

--- a/app/views/awrs_group_member.scala.html
+++ b/app/views/awrs_group_member.scala.html
@@ -27,6 +27,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -88,7 +89,9 @@ if(accountUtils.hasAwrs(enrolments)) {
     )
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", pageHeading), pageScripts = Some(pageScripts), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(groupMemberForm)} ${messages("awrs.generic.tab.title", pageHeading)}",
+    pageScripts = Some(pageScripts), userLoggedIn = true) {
 <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/dropdowns-enhancement.min.css")'/>
 
         @backLinkHelper(BackLinkParams(

--- a/app/views/awrs_group_representative_change_confirm.scala.html
+++ b/app/views/awrs_group_representative_change_confirm.scala.html
@@ -21,6 +21,7 @@
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
 @import views.html.helpers._
 @import views.view_application.helpers._
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -39,7 +40,9 @@
         </ul>
     }
 
-    @awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.business_name_change.heading")), userLoggedIn = true) {
+    @awrsMain(
+        title = s"${errorPrefix(confirmationForm)} ${messages("awrs.generic.tab.title", messages("awrs.business_name_change.heading"))}",
+        userLoggedIn = true) {
 
         @backLink()
 

--- a/app/views/awrs_legislation_date.scala.html
+++ b/app/views/awrs_legislation_date.scala.html
@@ -23,6 +23,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -40,7 +41,9 @@
     }
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.generic.legislation_before")), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(confirmationForm)} ${messages("awrs.generic.tab.title", messages("awrs.generic.legislation_before"))}",
+    userLoggedIn = true) {
     @backLink(controllers.routes.TradingNameController.showTradingName(true).url)
 
     @if(confirmationForm.errors.nonEmpty) {

--- a/app/views/awrs_partner_member_details.scala.html
+++ b/app/views/awrs_partner_member_details.scala.html
@@ -26,6 +26,7 @@
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -90,7 +91,9 @@
     }
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", h1text), pageScripts = Some(pageScripts), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(partnerForm)} ${messages(messages("awrs.generic.tab.title", h1text))}",
+    pageScripts = Some(pageScripts), userLoggedIn = true) {
     <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/dropdowns-enhancement.min.css")'/>
 
             @backLinkHelper(BackLinkParams(

--- a/app/views/awrs_principal_place_of_business.scala.html
+++ b/app/views/awrs_principal_place_of_business.scala.html
@@ -26,6 +26,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -91,7 +92,9 @@ messages(s"awrs.generic.principal.address_$line", "Previous principal")
 Messages("awrs.generic.principal.postcode", "Previous principal")
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", businessTypeHeading), pageScripts = Some(pageScripts), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(placeOfBusinessForm)} ${messages("awrs.generic.tab.title", businessTypeHeading)}",
+    pageScripts = Some(pageScripts), userLoggedIn = true) {
     <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/dropdowns-enhancement.min.css")'/>
 
             @backLinkHelper(BackLinkParams(

--- a/app/views/awrs_products.scala.html
+++ b/app/views/awrs_products.scala.html
@@ -26,6 +26,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichCheckboxes
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -81,7 +82,9 @@
     )
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", pageHeading), userLoggedIn = true){
+@awrsMain(
+    title = s"${errorPrefix(productsForm)} ${messages("awrs.generic.tab.title", pageHeading)}",
+    userLoggedIn = true){
 
 
         @backLinkHelper(BackLinkParams(

--- a/app/views/awrs_reapplication_confirmation.scala.html
+++ b/app/views/awrs_reapplication_confirmation.scala.html
@@ -20,6 +20,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -30,7 +31,9 @@
 @(reapplicationForm: Form[models.ReapplicationConfirmation])(implicit request: Request[AnyRef], messages: Messages, applicationConfig: ApplicationConfig)
 
 
-@awrsMain(messages("awrs.generic.tab.title", messages("awrs.reapplication.confirm_page.heading")), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(reapplicationForm)} ${messages("awrs.generic.tab.title", messages("awrs.reapplication.confirm_page.heading"))}",
+    userLoggedIn = true) {
 
         @backLink()
         @if(reapplicationForm.errors.nonEmpty) {

--- a/app/views/awrs_supplier_addresses.scala.html
+++ b/app/views/awrs_supplier_addresses.scala.html
@@ -24,6 +24,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.Implicits._
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -86,7 +87,9 @@
     messages("awrs.generic.tab.title", pageHeading)
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", pageHeading), pageScripts = Some(pageScripts), userLoggedIn = true){
+@awrsMain(
+    title = s"${errorPrefix(supplierAddressForm)} ${messages("awrs.generic.tab.title", pageHeading)}",
+    pageScripts = Some(pageScripts), userLoggedIn = true){
 <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/jquery-ui.min.css")'/>
 <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/dropdowns-enhancement.min.css")'/>
 

--- a/app/views/awrs_trading_activity.scala.html
+++ b/app/views/awrs_trading_activity.scala.html
@@ -27,6 +27,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichInput
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -109,7 +110,8 @@
 }
 
 @awrsMain(
-    title = messages("awrs.generic.tab.title", pageHeading), userLoggedIn = true){
+    title = s"${errorPrefix(tradingActivityForm)} ${messages("awrs.generic.tab.title", pageHeading)}",
+    userLoggedIn = true){
 
         @backLinkHelper(BackLinkParams(
             sectionName = tradingActivityName

--- a/app/views/awrs_trading_date.scala.html
+++ b/app/views/awrs_trading_date.scala.html
@@ -22,6 +22,7 @@
 @import views.view_application.helpers.SubViewTemplateHelper._
 @import views.view_application.helpers._
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichDateInput
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -80,7 +81,9 @@
     )
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", messages(headerTitleName)), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(confirmationForm)} ${messages("awrs.generic.tab.title", messages(headerTitleName))}",
+    userLoggedIn = true) {
 
 @backLink(controllers.routes.TradingLegislationDateController.showBusinessDetails().url)
 

--- a/app/views/awrs_trading_name.scala.html
+++ b/app/views/awrs_trading_name.scala.html
@@ -26,6 +26,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits._
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -102,7 +103,9 @@
     )
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", Messages("awrs.generic.do_you_have_trading_name")), userLoggedIn = true){
+@awrsMain(
+    title = s"${errorPrefix(businessDetailsForm)} ${messages("awrs.generic.tab.title", messages("awrs.generic.do_you_have_trading_name"))}",
+    userLoggedIn = true){
 
         @backLinkHelper(BackLinkParams(
             sectionName = businessDetailsName

--- a/app/views/awrs_withdrawal_confirmation.scala.html
+++ b/app/views/awrs_withdrawal_confirmation.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -33,7 +34,9 @@
     @awrsWarningHelper(declarationTxt = messages("awrs.generic.wait_info", messages("awrs.generic.wait_info_withdraw")), id = "confirmation-content")
 }
 
-@awrsMain(messages("awrs.generic.tab.title", messages("awrs.withdrawal.confirm_page.heading")), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(withdrawalConfirmationForm)} ${messages("awrs.generic.tab.title", messages("awrs.withdrawal.confirm_page.heading"))}",
+    userLoggedIn = true) {
 
     @backLink(backUrl = controllers.routes.WithdrawalController.showWithdrawalReasons.toString)
 

--- a/app/views/awrs_withdrawal_reasons.scala.html
+++ b/app/views/awrs_withdrawal_reasons.scala.html
@@ -22,6 +22,7 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits._
 @import views.view_application.helpers._
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -48,7 +49,9 @@
     )
 }
 
-    @awrsMain(messages("awrs.generic.tab.title", messages("awrs.withdrawal.reasons_page.heading")), userLoggedIn = true) {
+    @awrsMain(
+        title = s"${errorPrefix(withdrawalReasonForm)} ${messages("awrs.generic.tab.title", messages("awrs.withdrawal.reasons_page.heading"))}",
+        userLoggedIn = true) {
         @backLink(backUrl = controllers.routes.IndexController.showIndex.toString)
 
                 @if(withdrawalReasonForm.errors.nonEmpty) {

--- a/app/views/view_application/subviews/subview_delete_confirmation.scala.html
+++ b/app/views/view_application/subviews/subview_delete_confirmation.scala.html
@@ -24,6 +24,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
+@import views.ViewUtils._
 
 @this(
     formWithCSRF: FormWithCSRF,
@@ -43,7 +44,9 @@
     }
 }
 
-@awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.delete.confirmation_heading", messages(headingParameter))), userLoggedIn = true) {
+@awrsMain(
+    title = s"${errorPrefix(confirmationForm)} ${messages("awrs.generic.tab.title", messages("awrs.delete.confirmation_heading", messages(headingParameter)))}",
+    userLoggedIn = true) {
 @backLink(backUrl = controllers.routes.ViewApplicationController.viewSection(data match {
         case s : Supplier => suppliersName
         case p : AdditionalBusinessPremises => additionalBusinessPremisesName

--- a/conf/messages
+++ b/conf/messages
@@ -1,6 +1,7 @@
 # Generic messages
 #============================================================
 service.name=Register as an alcohol wholesaler or producer
+error.browser.title.prefix = Error:
 
 # Buttons & links
 #============================================================


### PR DESCRIPTION
Page title must be prefixed with Error: when it's possible for an error to occur on a page.
https://design.tax.service.gov.uk/hmrc-design-patterns/page-title/

## Before
![Screenshot 2021-12-20 at 11 14 37](https://user-images.githubusercontent.com/1692222/146758824-39531b9f-4f81-42ad-8c89-d2bf6322ccf5.png)

## After
![Screenshot 2021-12-20 at 11 14 00](https://user-images.githubusercontent.com/1692222/146758849-8a66f5bc-6a18-49dd-a038-413412b6ba5d.png)
