### PR TITLE
added describedBy to fieldset to link relevant info/hint to input

### DIFF
--- a/app/views/awrs_additional_premises.scala.html
+++ b/app/views/awrs_additional_premises.scala.html
@@ -95,6 +95,7 @@ govukErrorSummary: GovukErrorSummary)
                                 Radios(
                                     fieldset = Some(Fieldset(
                                         classes = "govuk-radios--inline",
+                                        describedBy = "additional-premises-subtext",
                                         legend = Some(Legend(
                                             content = Text(messages("awrs.additional-premises.top-heading.first")),
                                             classes = "govuk-visually-hidden"

--- a/app/views/awrs_supplier_addresses.scala.html
+++ b/app/views/awrs_supplier_addresses.scala.html
@@ -113,6 +113,7 @@
                         Radios(
                             fieldset = Some(Fieldset(
                                 classes = "govuk-radios--inline",
+                                describedBy = "supplier-address-description",
                                 legend = Some(Legend(
                                     content = Text(messages("awrs.supplier-addresses.heading.first")),
                                     classes = "govuk-visually-hidden"


### PR DESCRIPTION
Added describedBy to fieldset for hint text/relevant info association for accessibility.

Before:
![Screenshot 2021-12-09 at 11 37 07](https://user-images.githubusercontent.com/61423748/148205155-2eb09b6e-230b-4488-bece-a4211718503a.png)

After: 
As you can see for screen readers, it now reads out the relevant information that can be missed out if it was not linked.
<img width="1166" alt="Screenshot 2022-01-05 at 10 37 49" src="https://user-images.githubusercontent.com/61423748/148205232-4de865c1-fadf-42a2-8c67-eb90feed0412.png">

