### PR TITLE
DL-10448 restrict sending of UTR when empty as part of enrolment process

### DIFF
--- a/app/controllers/ApplicationDeclarationController.scala
+++ b/app/controllers/ApplicationDeclarationController.scala
@@ -109,8 +109,7 @@ class ApplicationDeclarationController @Inject()(enrolService: EnrolService,
               successResponse <- applicationService.sendApplication(ar)
               _ <- enrolService.enrolAWRS(applicationService.getRegistrationReferenceNumber(successResponse),
                 businessPartnerDetails.get,
-                businessType,
-                businessRegDetails.get.utr) // Calls ES8
+                businessType) // Calls ES8
             } yield {
               successResponse match {
                 case Left(_)         =>
@@ -134,6 +133,5 @@ class ApplicationDeclarationController @Inject()(enrolService: EnrolService,
       }
     }
   }
-
 
 }

--- a/app/services/CheckEtmpService.scala
+++ b/app/services/CheckEtmpService.scala
@@ -36,8 +36,7 @@ class CheckEtmpService @Inject()(awrsConnector: AWRSConnector,
         enrolService.enrolAWRS(
           successResponse.regimeRefNumber,
           busCusDetails,
-          legalEntity,
-          busCusDetails.utr
+          legalEntity
         ) map {
           case Some(_) =>
             logger.info("[CheckEtmpService][validateBusinessDetails] ES8 success")

--- a/test/controllers/ApplicationDeclarationControllerTest.scala
+++ b/test/controllers/ApplicationDeclarationControllerTest.scala
@@ -224,7 +224,7 @@ class ApplicationDeclarationControllerTest extends AwrsUnitTestTraits
     setupMockKeyStoreServiceOnlySaveFunctions()
     when(mockApplicationService.updateApplication(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(subscribeUpdateSuccessResponse))
     when(mockApplicationService.sendApplication(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Right(subscribeSuccessResponse)))
-    when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(enrolSuccessResponse)))
+    when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(enrolSuccessResponse)))
     val result = testApplicationDeclarationController.showApplicationDeclaration().apply(SessionBuilder.updateRequestWithSession(fakeRequest, userId, "SOP"))
     test(result)
   }
@@ -239,7 +239,7 @@ class ApplicationDeclarationControllerTest extends AwrsUnitTestTraits
     setupMockKeyStoreServiceOnlySaveFunctions()
     when(mockApplicationService.updateApplication(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(subscribeUpdateSuccessResponse))
     when(mockApplicationService.sendApplication(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Right(subscribeSuccessResponse)))
-    when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(enrolSuccessResponse)))
+    when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(enrolSuccessResponse)))
     val result = testApplicationDeclarationController.sendApplication().apply(SessionBuilder.updateRequestWithSession(fakeRequest, userId, "SOP"))
     test(result)
   }
@@ -256,7 +256,7 @@ class ApplicationDeclarationControllerTest extends AwrsUnitTestTraits
     setupMockKeyStoreServiceOnlySaveFunctions()
     when(mockApplicationService.updateApplication(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(subscribeUpdateSuccessResponse))
     when(mockApplicationService.sendApplication(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Left(selfHealSuccessResponse)))
-    when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(enrolSuccessResponse)))
+    when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(enrolSuccessResponse)))
     val result = testApplicationDeclarationController.sendApplication().apply(SessionBuilder.updateRequestWithSession(fakeRequest, userId, "SOP"))
     test(result)
   }
@@ -283,7 +283,7 @@ class ApplicationDeclarationControllerTest extends AwrsUnitTestTraits
     }
     when(mockApplicationService.updateApplication(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.failed(exception))
     when(mockApplicationService.sendApplication(ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.failed(exception))
-    when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(enrolSuccessResponse)))
+    when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(Some(enrolSuccessResponse)))
 
     val result = testApplicationDeclarationController.sendApplication().apply(SessionBuilder.updateRequestWithSession(fakeRequest, userId, "SOP"))
     test(result)

--- a/test/services/CheckEtmpServiceTest.scala
+++ b/test/services/CheckEtmpServiceTest.scala
@@ -43,8 +43,8 @@ class CheckEtmpServiceTest extends PlaySpec with MockitoSugar with BeforeAndAfte
   val mockEnrolService: EnrolService = mock[EnrolService]
   val mockSave4LaterConnector: Save4LaterConnector = mock[Save4LaterConnector]
   val mockAccountUtils: AccountUtils = mock[AccountUtils]
-  val testBusinessCustomerDetails = BusinessCustomerDetails("ACME", Some("SOP"), BCAddress("line1", "line2", Option("line3"), Option("line4"), Option("postcode"), Option("country")), "sap123", "safe123", false, Some("agent123"))
-  val testBusinessRegistrationDetails = BusinessRegistrationDetails(Some("SOP"), None, Some("1234"))
+  val testBusinessCustomerDetails: BusinessCustomerDetails = BusinessCustomerDetails("ACME", Some("SOP"), BCAddress("line1", "line2", Option("line3"), Option("line4"), Option("postcode"), Option("country")), "sap123", "safe123", false, Some("agent123"))
+  val testBusinessRegistrationDetails: BusinessRegistrationDetails = BusinessRegistrationDetails(Some("SOP"), None, Some("1234"))
   val checkEtmpTest = new CheckEtmpService(mockAwrsConnector, mockEnrolService)
 
   override def beforeEach(): Unit = {
@@ -62,7 +62,7 @@ class CheckEtmpServiceTest extends PlaySpec with MockitoSugar with BeforeAndAfte
     "return true if all details are provided" in {
       when(mockAwrsConnector.checkEtmp(any(), any())(any(), any()))
         .thenReturn(Future.successful(Some(SelfHealSubscriptionResponse("123456"))))
-      when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
+      when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(Some(enrolSuccessResponse)))
 
       val result = checkEtmpTest.validateBusinessDetails(testBusinessCustomerDetails, "SOP")
@@ -73,7 +73,7 @@ class CheckEtmpServiceTest extends PlaySpec with MockitoSugar with BeforeAndAfte
     "return false if enrol AWRS ES8 fails" in {
       when(mockAwrsConnector.checkEtmp(any(), any())(any(), any()))
         .thenReturn(Future.successful(Some(SelfHealSubscriptionResponse("123456"))))
-      when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
+      when(mockEnrolService.enrolAWRS(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(None))
 
       val result = checkEtmpTest.validateBusinessDetails(testBusinessCustomerDetails, "SOP")

--- a/test/services/EnrolServiceTest.scala
+++ b/test/services/EnrolServiceTest.scala
@@ -21,7 +21,6 @@ import connectors.TaxEnrolmentsConnector
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import uk.gov.hmrc.auth.core.authorise.{EmptyPredicate, Predicate}
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
@@ -35,28 +34,27 @@ class EnrolServiceTest extends AwrsUnitTestTraits {
   val userId = ""
   val saUtr: String = testUtr
   val ctUtr: String = testCTUtr
-  val enrolRequestSAUTR =  EnrolRequest(portalId = "Default", serviceName = "HMRC-AWRS-ORG",
+  val postCode: String = testPostcode
+  val enrolRequestSAUTR: EnrolRequest =  EnrolRequest(portalId = "Default", serviceName = "HMRC-AWRS-ORG",
     friendlyName = "AWRS Enrolment", knownFacts = Seq("XAAW000000123456","",saUtr,"postcode"))
-  val enrolRequestCTUTR =  EnrolRequest(portalId = "Default", serviceName = "HMRC-AWRS-ORG",
+  val enrolRequestCTUTR: EnrolRequest =  EnrolRequest(portalId = "Default", serviceName = "HMRC-AWRS-ORG",
     friendlyName = "AWRS Enrolment", knownFacts = Seq("XAAW000000123456",ctUtr,"","postcode"))
-  val enrolRequestNoSACT =  EnrolRequest(portalId = "Default", serviceName = "HMRC-AWRS-ORG",
+  val enrolRequestNoSACT: EnrolRequest =  EnrolRequest(portalId = "Default", serviceName = "HMRC-AWRS-ORG",
     friendlyName = "AWRS Enrolment", knownFacts = Seq("XAAW000000123456","","","postcode"))
-  val successfulEnrolResponse = Some(EnrolResponse(serviceName = "AWRS", state = "Not-activated",
+  val successfulEnrolResponse: Option[EnrolResponse] = Some(EnrolResponse(serviceName = "AWRS", state = "Not-activated",
     identifiers = List(Identifier("AWRS","Awrs-ref-no"))))
   val sourceId: String = "AWRS"
-  val testBusinessCustomerDetails = BusinessCustomerDetails("ACME", Some("SOP"),
+  val testBusinessCustomerDetails: BusinessCustomerDetails = BusinessCustomerDetails("ACME", Some("SOP"),
     BCAddress("line1", "line2", Option("line3"), Option("line4"), Option("post code"), Option("country")),
     "sap123", "safe123", false, Some("agent123"))
   val businessType = "LTD"
   val businessTypeSOP = "SOP"
 
-  val successfulSubscriptionResponse = SuccessfulSubscriptionResponse("","XAAW000000123456","")
+  val successfulSubscriptionResponse: SuccessfulSubscriptionResponse = SuccessfulSubscriptionResponse("","XAAW000000123456","")
   val mockAuthConnector: DefaultAuthConnector = mock[DefaultAuthConnector]
   val mockTaxEnrolmentsConnector: TaxEnrolmentsConnector = mock[TaxEnrolmentsConnector]
 
   val enrolServiceTest: EnrolService = new EnrolService(mockTaxEnrolmentsConnector, mockAuthConnector)
-
-  val enrolServiceEMACTest: EnrolService = new EnrolService(mockTaxEnrolmentsConnector, mockAuthConnector)
 
   override def beforeEach(): Unit = {
     reset(mockTaxEnrolmentsConnector)
@@ -66,11 +64,7 @@ class EnrolServiceTest extends AwrsUnitTestTraits {
     behave like enrolService(enrolServiceTest)
   }
 
-  "Enrol Service with EMAC switched on" must {
-    behave like enrolService(enrolServiceEMACTest)
-  }
-
-  def mockAuthorise[T](predicate: Predicate, retrieval: Retrieval[T])(result: T): Unit =
+  def mockAuthorise[T](predicate: Predicate)(result: T): Unit =
     when(mockAuthConnector.authorise[T](
       ArgumentMatchers.eq(predicate),
       ArgumentMatchers.any[Retrieval[T]]
@@ -82,26 +76,33 @@ class EnrolServiceTest extends AwrsUnitTestTraits {
 
   def enrolService(enrolService: EnrolService): Unit = {
     "fetch data if found in save4later" in {
-      mockAuthorise(EmptyPredicate, Retrievals.credentials and Retrievals.groupIdentifier)(new ~(Some(Credentials(testCredId, enrolService.GGProviderId)), Some(testGroupId)))
+      mockAuthorise(EmptyPredicate)(new ~(Some(Credentials(testCredId, enrolService.GGProviderId)), Some(testGroupId)))
       when(mockTaxEnrolmentsConnector.enrol(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
         .thenReturn(Future.successful(successfulEnrolResponse))
       val result = enrolService.enrolAWRS(successfulSubscriptionResponse.awrsRegistrationNumber,
-        testBusinessCustomerDetails, businessType, Some(testUtr))
+        testBusinessCustomerDetails, businessType)
       await(result) mustBe successfulEnrolResponse
     }
 
-    "create correct EnrolRequest when business type is SOP and UTR present " in {
-      val result = enrolService.createEnrolment(successfulSubscriptionResponse.awrsRegistrationNumber, testBusinessCustomerDetails, businessTypeSOP, saUtr)
-      result mustBe enrolRequestSAUTR
+    "create correct Verifiers when business type is SOP and UTR present " in {
+      val result = enrolService.createVerifiers(Some(saUtr), businessTypeSOP, postCode)
+      result mustBe List(
+        Verifier("Postcode", postCode), Verifier("SAUTR", saUtr)
+      )
     }
 
-    "create correct EnrolRequest when business type is other than SOP and UTR present " in {
-      val result = enrolService.createEnrolment(successfulSubscriptionResponse.awrsRegistrationNumber, testBusinessCustomerDetails, "LTD", ctUtr)
-      result mustBe enrolRequestCTUTR
+    "create correct Verifiers when business type is other than SOP and UTR present " in {
+      val result = enrolService.createVerifiers(Some(ctUtr), businessType, postCode)
+      result mustBe List(
+        Verifier("Postcode", postCode), Verifier("CTUTR", ctUtr)
+      )
     }
-    "create correct EnrolRequest when business type and UTR NOT present " in {
-      val result = enrolService.createEnrolment(successfulSubscriptionResponse.awrsRegistrationNumber, testBusinessCustomerDetails,"" , None)
-      result mustBe enrolRequestNoSACT
+
+    "create correct Verifiers when UTR NOT present " in {
+      val result = enrolService.createVerifiers(None, businessType, postCode)
+      result mustBe List(
+        Verifier("Postcode", postCode)
+      )
     }
   }
 


### PR DESCRIPTION
Amend def to only send UTR when  it is defined
Remove createEnrolment Def as the only part of this being used was the friendlyName element
Refactor with removal of the above
Implement tests to test createVerifiers def
Tidy changes and add annotations