### PR TITLE
Give edit and delete links for add address more context

### DIFF
--- a/app/views/view_application/ViewApplicationHelper.scala
+++ b/app/views/view_application/ViewApplicationHelper.scala
@@ -71,10 +71,40 @@ object ViewApplicationHelper {
     } + "</a>"
   }
 
+  def link_address(href: Option[String], message: String, classAttr: String, idAttr: Option[String] = None, visuallyHidden: String = ""): String = {
+    "<a " + {
+      val ida = idAttr match {
+        case Some(id) => "id=\"" + id + "\""
+        case _ => ""
+      }
+      ida
+    } + " class=\"" + classAttr + "\" href=\"" + href.get + "\">" + message + {
+      visuallyHidden match {
+        case "" => ""
+        case text => "<span class=\"govuk-visually-hidden\">" + "address " + text + "</span>"
+      }
+    } + "</a>"
+  }
+
   def edit_link(editUrl: Int => String, id: Int, visuallyHidden: String = "")(implicit viewApplicationType: ViewApplicationType): String = {
 
     if (isSectionEdit()) {
       link(
+        Some(editUrl(id)),
+        "Edit",
+        classAttr = "govuk-link govuk-!-padding-left-9",
+        idAttr = Some("edit-" + id),
+        visuallyHidden = visuallyHidden
+      )
+    } else {
+      NoneBreakingSpace
+    }
+  }
+
+  def edit_link_address(editUrl: Int => String, id: Int, visuallyHidden: String = "")(implicit viewApplicationType: ViewApplicationType): String = {
+
+    if (isSectionEdit()) {
+      link_address(
         Some(editUrl(id)),
         "Edit",
         classAttr = "govuk-link govuk-!-padding-left-9",
@@ -121,6 +151,21 @@ object ViewApplicationHelper {
 
     if (isSectionEdit()) {
       link(
+        Some(deleteUrl(id)),
+        "Delete",
+        classAttr = "govuk-link govuk-!-padding-left-3",
+        idAttr = Some("delete-" + id),
+        visuallyHidden = visuallyHidden
+      )
+    } else {
+      NoneBreakingSpace
+    }
+  }
+
+  def delete_link_address(deleteUrl: Int => String, id: Int, visuallyHidden: String = "")(implicit viewApplicationType: ViewApplicationType): String = {
+
+    if (isSectionEdit()) {
+      link_address(
         Some(deleteUrl(id)),
         "Delete",
         classAttr = "govuk-link govuk-!-padding-left-3",

--- a/app/views/view_application/subviews/contents/content_additional_premises.scala.html
+++ b/app/views/view_application/subviews/contents/content_additional_premises.scala.html
@@ -29,7 +29,7 @@
 
 @links = @{
     isEditMode match {
-        case true  => Some(List(edit_link(editUrl, id, premisesCounter), delete_link(deleteUrl, id, premisesCounter)))
+        case true  => Some(List(edit_link_address(editUrl, id, premisesCounter), delete_link_address(deleteUrl, id, premisesCounter)))
         case false => None
     }
 }


### PR DESCRIPTION
Before the links simply said edit/delete 1, edit/delete 2 and so on, I have added address so they now read edit/delete address 1, edit/delete address 2 and so on.

## Before
![Screenshot 2023-11-02 at 11 34 32](https://github.com/hmrc/awrs-frontend/assets/1692222/780e45f1-d04b-4b54-997b-7e1ba07b54cd)

## After
![Screenshot 2023-11-02 at 11 33 52](https://github.com/hmrc/awrs-frontend/assets/1692222/eabe8c76-2283-48cc-9ac9-89d71a4c2b65)
