### PR TITLE
Removing unnecessary aria-labelledby for postcode input

### DIFF
--- a/app/controllers/TradingLegislationDateController.scala
+++ b/app/controllers/TradingLegislationDateController.scala
@@ -70,7 +70,7 @@ class TradingLegislationDateController @Inject()(val mcc: MessagesControllerComp
                 case _ => Ok(template(tradingLegislationForm, businessType))
               }
             }
-          case _ => 
+          case _ =>
             Future.successful(Redirect(routes.TradingNameController.showTradingName(isLinearMode)))
         }
       }
@@ -79,7 +79,6 @@ class TradingLegislationDateController @Inject()(val mcc: MessagesControllerComp
 
   def saveBusinessDetails(id: Int, businessDetails: NewAWBusiness, redirectRoute: (Option[RedirectParam], Boolean) => Future[Result], authRetrievals: StandardAuthRetrievals)
                          (implicit hc: HeaderCarrier, viewApplicationType: ViewApplicationType): Future[Result] = {
- 
     save4LaterService.mainStore.saveTradingStartDetails(authRetrievals, businessDetails) flatMap {
       case NewAWBusiness(BooleanRadioEnum.YesString, _) =>
         keyStoreService.saveAlreadyTrading(already = true) flatMap { _ =>
@@ -101,7 +100,6 @@ class TradingLegislationDateController @Inject()(val mcc: MessagesControllerComp
               case _ =>
                 redirectRoute(Some(RedirectParam("No", id)), false)
             }
-            
           }
         }
     }
@@ -129,7 +127,7 @@ class TradingLegislationDateController @Inject()(val mcc: MessagesControllerComp
               saveBusinessDetails(id, awToSave, redirectRoute, authRetrievals)
             }
         )
-      case _ => 
+      case _ =>
         Future.successful(Redirect(routes.TradingNameController.showTradingName(viewMode == LinearViewMode)))
     }
   }

--- a/app/controllers/TradingNameController.scala
+++ b/app/controllers/TradingNameController.scala
@@ -81,7 +81,7 @@ class TradingNameController @Inject()(val mcc: MessagesControllerComponents,
                          (implicit hc: HeaderCarrier, viewMode: ViewApplicationType): Future[Result] = {
     save4LaterService.mainStore.saveBusinessNameDetails(authRetrievals, businessDetails) flatMap { _ =>
       businessDetailsService.businessDetailsPageRenderMode(authRetrievals) flatMap {
-        case NewApplicationMode => 
+        case NewApplicationMode =>
             viewMode match {
               case LinearViewMode =>
                 Future.successful(Redirect(routes.TradingLegislationDateController.showBusinessDetails(viewMode == LinearViewMode)))

--- a/app/controllers/ViewApplicationController.scala
+++ b/app/controllers/ViewApplicationController.scala
@@ -123,7 +123,7 @@ class ViewApplicationController @Inject()(mcc: MessagesControllerComponents,
               case None => ""
             }
             val displayNameKey = getSectionDisplayName(sectionName, legalEntity)
-            
+
             sectionName match {
               case `businessDetailsName` => showPage(views.html.view_application.subviews.subview_business_details(
                 displayNameKey, BusinessDetailSummaryModel(cacheMap.getBusinessNameDetails, cacheMap.getTradingStartDetails), Some(businessCustomerDetails.fold("")(x => x.businessName)), businessCustomerDetails.fold(false)(_.isAGroup))(viewApplicationType = EditRecordOnlyMode, implicitly, implicitly), legalEntity)

--- a/app/views/helpers/awrsInputTypeText.scala.html
+++ b/app/views/helpers/awrsInputTypeText.scala.html
@@ -125,13 +125,7 @@
            @maxLength
            @dataAttributes
            @if(fieldErrors.nonEmpty) {
-               aria-labelledby="@{params.field.name}-error-0@if(params.isDate){ @{inputId}_field @{inputId}_reader}"
-           } else {
-               @if(params.ariaLabelledBy.nonEmpty) {
-                    aria-labelledby="@{params.ariaLabelledBy}@if(params.isDate){ @{inputId}_field @{inputId}_reader}"
-                } else {
-                    aria-labelledby="@{inputId}_field@if(params.isDate){ @{inputId}_field @{inputId}_reader}"
-                }
+               aria-describedby="@{params.field.name}-error-0@if(params.isDate){ @{inputId}_field @{inputId}_reader}"
            }
     >
     @isPostCodeInput


### PR DESCRIPTION
I have also updated the aria-labelledby to the correct aria-describedby when the postcode field is left empty and triggers an errors.

## Before
![Screenshot 2023-10-03 at 16 44 58](https://github.com/hmrc/awrs-frontend/assets/1692222/519880c4-8d7f-4f0a-8813-d1ecb3fd7ae2)

## After
<img width="1509" alt="Screenshot 2023-11-06 at 11 20 34" src="https://github.com/hmrc/awrs-frontend/assets/1692222/bbd17127-b242-45b3-9f4a-dc94186e82b9">
<img width="1502" alt="Screenshot 2023-11-06 at 11 21 06" src="https://github.com/hmrc/awrs-frontend/assets/1692222/7c5e44a3-1de8-47dc-919f-65b24e469d16">
