### PR TITLE
DL-16131, increase emphasis on reenrolment journey

### DIFF
--- a/app/controllers/HaveYouRegisteredController.scala
+++ b/app/controllers/HaveYouRegisteredController.scala
@@ -69,7 +69,7 @@ class HaveYouRegisteredController @Inject()(val mcc: MessagesControllerComponent
             haveYouRegisteredData =>
               keyStoreService.saveHaveYouRegistered(haveYouRegisteredData) flatMap { _ =>
                 if (haveYouRegisteredData.hasUserRegistered.getOrElse(false)) {
-                  Future.successful(Redirect(controllers.routes.AwrsUrnController.showArwsUrnPage))
+                  Future.successful(Redirect(controllers.reenrolment.routes.RegisteredUrnController.showArwsUrnPage))
                 }
                 else {
                   Future.successful(Redirect(applicationConfig.businessCustomerStartPage))

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -36,11 +36,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class HomeController @Inject()(mcc: MessagesControllerComponents,
                                businessCustomerService: BusinessCustomerService,
                                val deEnrolService: DeEnrolService,
-                               val checkEtmpService: CheckEtmpService,
+                               checkEtmpService: CheckEtmpService,
                                val authConnector: DefaultAuthConnector,
                                val auditable: Auditable,
                                val accountUtils: AccountUtils,
-                               implicit val save4LaterService: Save4LaterService,
+                               implicit private val save4LaterService: Save4LaterService,
                                implicit val applicationConfig: ApplicationConfig,
                                templateTooSoon: views.html.awrs_application_too_soon_error,
                                templateAssistantKickout: views.html.assistant_kickout) extends FrontendController(mcc) with AwrsController {
@@ -49,59 +49,6 @@ class HomeController @Inject()(mcc: MessagesControllerComponents,
 
   implicit val ec: ExecutionContext = mcc.executionContext
   val signInUrl: String = applicationConfig.signIn
-
-  private def awrsIdentifier(authRetrievals: StandardAuthRetrievals)(implicit hc: HeaderCarrier): String = {
-    val awrsIdentifier = if (accountUtils.hasAwrs(authRetrievals.enrolments)) {
-      accountUtils.getAwrsRefNo(authRetrievals.enrolments)
-    } else {
-      save4LaterService.mainStore.fetchBusinessCustomerDetails(authRetrievals).map(_.get.safeId)
-    }
-    awrsIdentifier.toString
-  }
-
-  def api5Journey(callerId: Option[String])(implicit request: Request[AnyContent]): Future[Result] = {
-    debug("API5 journey triggered")
-    gotoBusinessTypePage(callerId)
-  }
-
-  private def gotoBusinessTypePage(callerId: Option[String])(implicit request: Request[AnyContent]): Future[Result] = {
-    callerId match {
-      case Some(id) => Future.successful(Redirect(controllers.routes.BusinessTypeController.showBusinessType(false)).addingToSession(AwrsSessionKeys.sessionCallerId -> id))
-      case _ => Future.successful(Redirect(controllers.routes.BusinessTypeController.showBusinessType(false)))
-    }
-  }
-
-  def businessCustomerDetails(authRetrievals: StandardAuthRetrievals, callerId: Option[String])(implicit request: Request[AnyContent]): Future[Option[BusinessCustomerDetails]] =
-    save4LaterService.mainStore.fetchBusinessCustomerDetails(authRetrievals) flatMap {
-      case Some(data) if data.safeId.nonEmpty =>
-        logger.info("[HomeController][businessCustomerDetails] - BC Details fetched from save4later")
-        Future.successful(Some(data))
-      case _ =>
-        logger.warn("[HomeController][businessCustomerDetails] - no valid BC Details found in save4later, checking Keystore")
-        businessCustomerService.getReviewBusinessDetails[BusinessCustomerDetails].flatMap {
-          case Some(data) =>
-            logger.info("[HomeController][businessCustomerDetails] - BC Details fetched from Keystore")
-            save4LaterService.mainStore.saveBusinessCustomerDetails(authRetrievals, data).map(_ => Some(data))
-          case _ =>
-            logger.warn("[HomeController][businessCustomerDetails] - no BC Details found in save4later or Keystore")
-            Future.successful(None)
-        }
-    }
-
-  def api4Journey(authRetrievals: StandardAuthRetrievals, callerId: Option[String])(implicit request: Request[AnyContent]): Future[Result] =
-    businessCustomerDetails(authRetrievals, callerId).flatMap {
-      _.fold(Future.successful(Redirect(applicationConfig.businessCustomerStartPage))) { details =>
-        checkEtmpService.checkUsersEnrolments(details, authRetrievals.plainTextCredId) flatMap { result =>
-          result match {
-            case Some(true) =>
-              logger.info(s"User business already has AWRS enrolment")
-              Future.successful(Redirect(controllers.routes.WrongAccountController.showWrongAccountPage(Some(details.businessName))))
-            case _ =>
-              gotoBusinessTypePage(callerId)
-          }
-        }
-      }
-    }
 
   def showOrRedirect(callerId: Option[String] = None): Action[AnyContent] = Action.async { implicit request =>
     authorisedAction { authRetrievals =>
@@ -122,6 +69,59 @@ class HomeController @Inject()(mcc: MessagesControllerComponents,
     }
   }
 
+  private def awrsIdentifier(authRetrievals: StandardAuthRetrievals)(implicit hc: HeaderCarrier): String = {
+    val awrsIdentifier = if (accountUtils.hasAwrs(authRetrievals.enrolments)) {
+      accountUtils.getAwrsRefNo(authRetrievals.enrolments)
+    } else {
+      save4LaterService.mainStore.fetchBusinessCustomerDetails(authRetrievals).map(_.get.safeId)
+    }
+    awrsIdentifier.toString
+  }
+
+  private def api5Journey(callerId: Option[String])(implicit request: Request[AnyContent]): Future[Result] = {
+    debug("API5 journey triggered")
+    gotoBusinessTypePage(callerId)
+  }
+
+  private def gotoBusinessTypePage(callerId: Option[String])(implicit request: Request[AnyContent]): Future[Result] = {
+    callerId match {
+      case Some(id) => Future.successful(Redirect(controllers.routes.BusinessTypeController.showBusinessType(false)).addingToSession(AwrsSessionKeys.sessionCallerId -> id))
+      case _ => Future.successful(Redirect(controllers.routes.BusinessTypeController.showBusinessType(false)))
+    }
+  }
+
+  private def businessCustomerDetails(authRetrievals: StandardAuthRetrievals, callerId: Option[String])(implicit request: Request[AnyContent]): Future[Option[BusinessCustomerDetails]] =
+    save4LaterService.mainStore.fetchBusinessCustomerDetails(authRetrievals) flatMap {
+      case Some(data) if data.safeId.nonEmpty =>
+        logger.info("[HomeController][businessCustomerDetails] - BC Details fetched from save4later")
+        Future.successful(Some(data))
+      case _ =>
+        logger.warn("[HomeController][businessCustomerDetails] - no valid BC Details found in save4later, checking Keystore")
+        businessCustomerService.getReviewBusinessDetails[BusinessCustomerDetails].flatMap {
+          case Some(data) =>
+            logger.info("[HomeController][businessCustomerDetails] - BC Details fetched from Keystore")
+            save4LaterService.mainStore.saveBusinessCustomerDetails(authRetrievals, data).map(_ => Some(data))
+          case _ =>
+            logger.warn("[HomeController][businessCustomerDetails] - no BC Details found in save4later or Keystore")
+            Future.successful(None)
+        }
+    }
+
+  private def api4Journey(authRetrievals: StandardAuthRetrievals, callerId: Option[String])(implicit request: Request[AnyContent]): Future[Result] =
+    businessCustomerDetails(authRetrievals, callerId).flatMap {
+      _.fold(Future.successful(Redirect(applicationConfig.businessCustomerStartPage))) { details =>
+        checkEtmpService.checkUsersEnrolments(details, authRetrievals.plainTextCredId) flatMap { result =>
+          result match {
+            case Some(true) =>
+              logger.info(s"User business already has AWRS enrolment")
+              Future.successful(Redirect(controllers.routes.WrongAccountController.showWrongAccountPage(Some(details.businessName))))
+            case _ =>
+              gotoBusinessTypePage(callerId)
+          }
+        }
+      }
+    }
+
   private def chooseScenario(callerId: Option[String], authRetrievals: StandardAuthRetrievals)
                             (implicit request: Request[AnyContent]): Future[Result] = {
     save4LaterService.mainStore.fetchApplicationStatus(authRetrievals) flatMap {
@@ -132,7 +132,7 @@ class HomeController @Inject()(mcc: MessagesControllerComponents,
     }
   }
 
-  def checkValidApplicationStatus(applicationStatus: ApplicationStatus, callerId: Option[String], authRetrievals: StandardAuthRetrievals)
+  private def checkValidApplicationStatus(applicationStatus: ApplicationStatus, callerId: Option[String], authRetrievals: StandardAuthRetrievals)
                                  (implicit request: Request[AnyContent]): Future[Result] =
   // check that the user has not returned within the specified amount of hours since de-registering or withdrawing their application
     if (applicationStatus.updatedDate.isBefore(LocalDateTime.now().minusHours(MinReturnHours))) {
@@ -141,7 +141,7 @@ class HomeController @Inject()(mcc: MessagesControllerComponents,
       Future.successful(InternalServerError(templateTooSoon(applicationStatus)))
     }
 
-  def startJourney(callerId: Option[String], authRetrievals: StandardAuthRetrievals)
+  private def startJourney(callerId: Option[String], authRetrievals: StandardAuthRetrievals)
                   (implicit request: Request[AnyContent]): Future[Result] =
     if (accountUtils.hasAwrs(authRetrievals.enrolments)) {
       api5Journey(callerId)(request)

--- a/app/controllers/reenrolment/KickoutController.scala
+++ b/app/controllers/reenrolment/KickoutController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers
+package controllers.reenrolment
 
 import audit.Auditable
 import config.ApplicationConfig
@@ -28,15 +28,14 @@ import utils.{AWRSFeatureSwitches, AccountUtils}
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class AwrsUrnKickoutController @Inject()(mcc: MessagesControllerComponents,
-                                         implicit val applicationConfig: ApplicationConfig,
-                                         val awrsFeatureSwitches: AWRSFeatureSwitches,
-                                         val deEnrolService: DeEnrolService,
-                                         val authConnector: DefaultAuthConnector,
-
-                                         val accountUtils: AccountUtils,
-                                         val auditable: Auditable,
-                                         template: views.html.urn_kickout
+class KickoutController @Inject()(mcc: MessagesControllerComponents,
+                                  implicit val applicationConfig: ApplicationConfig,
+                                  val awrsFeatureSwitches: AWRSFeatureSwitches,
+                                  val deEnrolService: DeEnrolService,
+                                  val authConnector: DefaultAuthConnector,
+                                  val accountUtils: AccountUtils,
+                                  val auditable: Auditable,
+                                  template: views.html.reenrolment.awrs_reenrolment_kickout
                                             ) extends FrontendController(mcc) with AwrsController {
 
   implicit val ec: ExecutionContext = mcc.executionContext

--- a/app/controllers/reenrolment/RegisteredPostcodeController.scala
+++ b/app/controllers/reenrolment/RegisteredPostcodeController.scala
@@ -29,14 +29,14 @@ import utils.{AWRSFeatureSwitches, AccountUtils}
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class RegisteredPostcodeController @Inject()(val mcc: MessagesControllerComponents,
+class RegisteredPostcodeController @Inject()(mcc: MessagesControllerComponents,
                                              implicit val applicationConfig: ApplicationConfig,
                                              val authConnector: DefaultAuthConnector,
                                              val accountUtils: AccountUtils,
                                              val deEnrolService: DeEnrolService,
                                              val auditable: Auditable,
-                                             val awrsFeatureSwitches: AWRSFeatureSwitches,
-                                             val keyStoreService: KeyStoreService,
+                                             awrsFeatureSwitches: AWRSFeatureSwitches,
+                                             keyStoreService: KeyStoreService,
                                              template: views.html.reenrolment.awrs_registered_postcode) extends FrontendController(mcc) with AwrsController {
 
 

--- a/app/controllers/reenrolment/RegisteredPostcodeController.scala
+++ b/app/controllers/reenrolment/RegisteredPostcodeController.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package controllers
+package controllers.reenrolment
 
 import audit.Auditable
 import config.ApplicationConfig
 import controllers.auth.AwrsController
-import forms.AwrsRegisteredPostcodeForm.awrsRegisteredPostcodeForm
+import forms.reenrolment.RegisteredPostcodeForm.awrsRegisteredPostcodeForm
 import play.api.mvc._
 import services.{DeEnrolService, KeyStoreService}
 import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
@@ -29,18 +29,18 @@ import utils.{AWRSFeatureSwitches, AccountUtils}
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class AwrsRegisteredPostcodeController @Inject()(val mcc: MessagesControllerComponents,
-                                                 implicit val applicationConfig: ApplicationConfig,
-                                                 val authConnector: DefaultAuthConnector,
-                                                 val accountUtils: AccountUtils,
-                                                 val deEnrolService: DeEnrolService,
-                                                 val auditable: Auditable,
-                                                 val awrsFeatureSwitches: AWRSFeatureSwitches,
-                                                 val keyStoreService: KeyStoreService,
-                                                 template: views.html.awrs_registered_postcode) extends FrontendController(mcc) with AwrsController {
+class RegisteredPostcodeController @Inject()(val mcc: MessagesControllerComponents,
+                                             implicit val applicationConfig: ApplicationConfig,
+                                             val authConnector: DefaultAuthConnector,
+                                             val accountUtils: AccountUtils,
+                                             val deEnrolService: DeEnrolService,
+                                             val auditable: Auditable,
+                                             val awrsFeatureSwitches: AWRSFeatureSwitches,
+                                             val keyStoreService: KeyStoreService,
+                                             template: views.html.reenrolment.awrs_registered_postcode) extends FrontendController(mcc) with AwrsController {
 
- 
-  val signInUrl = applicationConfig.signIn
+
+  val signInUrl: String = applicationConfig.signIn
   implicit val ec: ExecutionContext = mcc.executionContext
 
   def showPostCode(): Action[AnyContent] = Action.async { implicit request: Request[AnyContent] =>
@@ -51,20 +51,19 @@ class AwrsRegisteredPostcodeController @Inject()(val mcc: MessagesControllerComp
             case Some(registeredPostcode) => Ok(template(awrsRegisteredPostcodeForm.form.fill(registeredPostcode)))
             case _ => Ok(template(awrsRegisteredPostcodeForm.form))
           }
-        else
-          Future.successful(NotFound)
+        else Future.successful(NotFound)
       }
     }
-   }
+  }
 
-  def saveAndContinue = Action.async { implicit request: Request[AnyContent] =>
+  def saveAndContinue: Action[AnyContent] = Action.async { implicit request: Request[AnyContent] =>
     enrolmentEligibleAuthorisedAction { implicit ar =>
       restrictedAccessCheck {
         awrsRegisteredPostcodeForm.bindFromRequest().fold(
           formWithErrors => Future.successful(BadRequest(template(formWithErrors))),
           postcode => {
             keyStoreService.saveAwrsRegisteredPostcode(postcode) flatMap {
-              _ => Future.successful(Redirect(controllers.routes.AwrsUtrController.showArwsUtrPage))
+              _ => Future.successful(Redirect(controllers.reenrolment.routes.RegisteredUtrController.showArwsUtrPage))
             }
           })
       }

--- a/app/controllers/reenrolment/RegisteredUrnController.scala
+++ b/app/controllers/reenrolment/RegisteredUrnController.scala
@@ -31,13 +31,13 @@ import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class RegisteredUrnController @Inject()(mcc: MessagesControllerComponents,
-                                        val keyStoreService: KeyStoreService,
+                                        keyStoreService: KeyStoreService,
                                         val deEnrolService: DeEnrolService,
                                         val authConnector: DefaultAuthConnector,
                                         val auditable: Auditable,
                                         val accountUtils: AccountUtils,
                                         lookupService: LookupService,
-                                        val awrsFeatureSwitches: AWRSFeatureSwitches,
+                                        awrsFeatureSwitches: AWRSFeatureSwitches,
                                         implicit val applicationConfig: ApplicationConfig,
                                         template: views.html.reenrolment.awrs_registered_urn
                                       ) extends FrontendController(mcc) with AwrsController {

--- a/app/controllers/reenrolment/RegisteredUrnController.scala
+++ b/app/controllers/reenrolment/RegisteredUrnController.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package controllers
+package controllers.reenrolment
 
 
 import audit.Auditable
 import config.ApplicationConfig
 import controllers.auth.AwrsController
-import forms.AwrsEnrolmentUrnForm.awrsEnrolmentUrnForm
+import forms.reenrolment.RegisteredUrnForm.awrsEnrolmentUrnForm
 import play.api.mvc._
 import services.{DeEnrolService, KeyStoreService, LookupService}
 import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
@@ -30,16 +30,16 @@ import utils.{AWRSFeatureSwitches, AccountUtils}
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class AwrsUrnController @Inject()(mcc: MessagesControllerComponents,
-                                  val keyStoreService: KeyStoreService,
-                                  val deEnrolService: DeEnrolService,
-                                  val authConnector: DefaultAuthConnector,
-                                  val auditable: Auditable,
-                                  val accountUtils: AccountUtils,
-                                  lookupService: LookupService,
-                                  val awrsFeatureSwitches: AWRSFeatureSwitches,
-                                  implicit val applicationConfig: ApplicationConfig,
-                                  template: views.html.awrs_urn
+class RegisteredUrnController @Inject()(mcc: MessagesControllerComponents,
+                                        val keyStoreService: KeyStoreService,
+                                        val deEnrolService: DeEnrolService,
+                                        val authConnector: DefaultAuthConnector,
+                                        val auditable: Auditable,
+                                        val accountUtils: AccountUtils,
+                                        lookupService: LookupService,
+                                        val awrsFeatureSwitches: AWRSFeatureSwitches,
+                                        implicit val applicationConfig: ApplicationConfig,
+                                        template: views.html.reenrolment.awrs_registered_urn
                                       ) extends FrontendController(mcc) with AwrsController {
 
   implicit val ec: ExecutionContext = mcc.executionContext
@@ -68,8 +68,8 @@ class AwrsUrnController @Inject()(mcc: MessagesControllerComponents,
               keyStoreService.saveAwrsEnrolmentUrn(awrsUrn) flatMap { _ =>
                 lookupService.lookup(awrsUrn.awrsUrn).flatMap { _ match {
                     case Some(searchResult) => keyStoreService.saveAwrsUrnSearchResult(searchResult)
-                      Future.successful(Redirect(routes.AwrsRegisteredPostcodeController.showPostCode))
-                    case None => Future.successful(Redirect(routes.AwrsUrnKickoutController.showURNKickOutPage))
+                      Future.successful(Redirect(routes.RegisteredPostcodeController.showPostCode))
+                    case None => Future.successful(Redirect(routes.KickoutController.showURNKickOutPage))
                   }
                 }
               }

--- a/app/controllers/reenrolment/RegisteredUtrController.scala
+++ b/app/controllers/reenrolment/RegisteredUtrController.scala
@@ -30,14 +30,14 @@ import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class RegisteredUtrController @Inject()(mcc: MessagesControllerComponents,
-                                        val keyStoreService: KeyStoreService,
+                                        keyStoreService: KeyStoreService,
                                         val deEnrolService: DeEnrolService,
                                         val authConnector: DefaultAuthConnector,
                                         val auditable: Auditable,
                                         val accountUtils: AccountUtils,
-                                        val businessMatchingService: BusinessMatchingService,
+                                        businessMatchingService: BusinessMatchingService,
                                         val enrolService: EnrolService,
-                                        val awrsFeatureSwitches: AWRSFeatureSwitches,
+                                        awrsFeatureSwitches: AWRSFeatureSwitches,
                                         implicit val applicationConfig: ApplicationConfig,
                                         template: views.html.reenrolment.awrs_registered_utr
                                  ) extends FrontendController(mcc) with AwrsController {

--- a/app/controllers/reenrolment/RegisteredUtrController.scala
+++ b/app/controllers/reenrolment/RegisteredUtrController.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package controllers
+package controllers.reenrolment
 
 import audit.Auditable
 import config.ApplicationConfig
 import controllers.auth.AwrsController
-import forms.AwrsEnrolmentUtrForm.awrsEnrolmentUtrForm
+import forms.reenrolment.RegisteredUtrForm.awrsEnrolmentUtrForm
 import play.api.mvc._
 import services.{BusinessMatchingService, DeEnrolService, EnrolService, KeyStoreService}
 import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
@@ -29,17 +29,17 @@ import utils.{AWRSFeatureSwitches, AccountUtils}
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class AwrsUtrController @Inject()(mcc: MessagesControllerComponents,
-                                  val keyStoreService: KeyStoreService,
-                                  val deEnrolService: DeEnrolService,
-                                  val authConnector: DefaultAuthConnector,
-                                  val auditable: Auditable,
-                                  val accountUtils: AccountUtils,
-                                  val businessMatchingService: BusinessMatchingService,
-                                  val enrolService: EnrolService,
-                                  val awrsFeatureSwitches: AWRSFeatureSwitches,
-                                  implicit val applicationConfig: ApplicationConfig,
-                                  template: views.html.awrs_utr
+class RegisteredUtrController @Inject()(mcc: MessagesControllerComponents,
+                                        val keyStoreService: KeyStoreService,
+                                        val deEnrolService: DeEnrolService,
+                                        val authConnector: DefaultAuthConnector,
+                                        val auditable: Auditable,
+                                        val accountUtils: AccountUtils,
+                                        val businessMatchingService: BusinessMatchingService,
+                                        val enrolService: EnrolService,
+                                        val awrsFeatureSwitches: AWRSFeatureSwitches,
+                                        implicit val applicationConfig: ApplicationConfig,
+                                        template: views.html.reenrolment.awrs_registered_utr
                                  ) extends FrontendController(mcc) with AwrsController {
 
   implicit val ec: ExecutionContext = mcc.executionContext
@@ -80,7 +80,7 @@ class AwrsUtrController @Inject()(mcc: MessagesControllerComponents,
                         Redirect(routes.SuccessfulEnrolmentController.showSuccessfulEnrolmentPage)
                       }
                     } else {
-                      Future.successful(Redirect(routes.AwrsUrnKickoutController.showURNKickOutPage))
+                      Future.successful(Redirect(routes.KickoutController.showURNKickOutPage))
                     }
                   }
                 }

--- a/app/controllers/reenrolment/SuccessfulEnrolmentController.scala
+++ b/app/controllers/reenrolment/SuccessfulEnrolmentController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers
+package controllers.reenrolment
 
 import audit.Auditable
 import config.ApplicationConfig
@@ -35,12 +35,11 @@ class SuccessfulEnrolmentController @Inject()(mcc: MessagesControllerComponents,
                                               val auditable: Auditable,
                                               val awrsFeatureSwitches: AWRSFeatureSwitches,
                                               val accountUtils: AccountUtils,
-                                              template: views.html.awrs_successful_enrolment
+                                              template: views.html.reenrolment.awrs_successful_enrolment
                                              ) extends FrontendController(mcc) with AwrsController {
 
   implicit val ec: ExecutionContext = mcc.executionContext
   val signInUrl: String = applicationConfig.signIn
-
 
   def showSuccessfulEnrolmentPage(): Action[AnyContent] = Action.async { implicit request =>
       if (awrsFeatureSwitches.enrolmentJourney().enabled) {

--- a/app/controllers/reenrolment/SuccessfulEnrolmentController.scala
+++ b/app/controllers/reenrolment/SuccessfulEnrolmentController.scala
@@ -33,7 +33,7 @@ class SuccessfulEnrolmentController @Inject()(mcc: MessagesControllerComponents,
                                               val deEnrolService: DeEnrolService,
                                               val authConnector: DefaultAuthConnector,
                                               val auditable: Auditable,
-                                              val awrsFeatureSwitches: AWRSFeatureSwitches,
+                                              awrsFeatureSwitches: AWRSFeatureSwitches,
                                               val accountUtils: AccountUtils,
                                               template: views.html.reenrolment.awrs_successful_enrolment
                                              ) extends FrontendController(mcc) with AwrsController {
@@ -42,12 +42,10 @@ class SuccessfulEnrolmentController @Inject()(mcc: MessagesControllerComponents,
   val signInUrl: String = applicationConfig.signIn
 
   def showSuccessfulEnrolmentPage(): Action[AnyContent] = Action.async { implicit request =>
-      if (awrsFeatureSwitches.enrolmentJourney().enabled) {
-        Future.successful(Ok(template()))
-      } else {
-        Future.successful(NotFound)
-      }
+    if (awrsFeatureSwitches.enrolmentJourney().enabled) {
+      Future.successful(Ok(template()))
+    } else {
+      Future.successful(NotFound)
+    }
   }
-
-
 }

--- a/app/forms/HaveYouRegisteredForm.scala
+++ b/app/forms/HaveYouRegisteredForm.scala
@@ -30,7 +30,7 @@ object HaveYouRegisteredForm {
   val hasUserRegistered = "hasUserRegistered"
 
   val haveYouRegisteredFormCompulsoryBooleanMappingParam= compulsoryBoolean(CompulsoryBooleanMappingParameter(
-    empty = simpleFieldIsEmptyConstraintParameter(hasUserRegistered, "awrs.enrolment.have_you_registered.error"),
+    empty = simpleFieldIsEmptyConstraintParameter(hasUserRegistered, "awrs.have_you_registered.error"),
     enumType = BooleanCheckboxEnum
   ))
 

--- a/app/forms/reenrolment/RegisteredPostcodeForm.scala
+++ b/app/forms/reenrolment/RegisteredPostcodeForm.scala
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-package forms
+package forms.reenrolment
 
 import forms.prevalidation._
 import forms.validation.util.ConstraintUtil.{CompulsoryTextFieldMappingParameter, FieldFormatConstraintParameter}
 import forms.validation.util.ErrorMessagesUtilAPI.simpleFieldIsEmptyConstraintParameter
 import forms.validation.util.MappingUtilAPI.{MappingUtil, compulsoryText}
-import models.AwrsRegisteredPostcode
+import models.reenrolment.AwrsRegisteredPostcode
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.data.validation.{Invalid, Valid}
 import utils.AwrsValidator
 
-object AwrsRegisteredPostcodeForm extends AwrsValidator{
+object RegisteredPostcodeForm extends AwrsValidator{
 
   val registeredPostcode = "registeredPostcode"
 
@@ -36,7 +36,7 @@ object AwrsRegisteredPostcodeForm extends AwrsValidator{
         if (AwrsRegisteredPostcode.sanitise(registeredPostcode).matches(postcodeRegex)) {
           Valid
         } else {
-          Invalid("awrs.register_postcode.error.invalid_postcode")
+          Invalid("awrs.reenrolment.registered_postcode.error.invalid_postcode")
         }
       }
     )
@@ -44,7 +44,7 @@ object AwrsRegisteredPostcodeForm extends AwrsValidator{
 
   private lazy val compulsoryQueryField = compulsoryText(
     CompulsoryTextFieldMappingParameter(
-      empty = simpleFieldIsEmptyConstraintParameter(registeredPostcode, "awrs.register_postcode.error.empty"),
+      empty = simpleFieldIsEmptyConstraintParameter(registeredPostcode, "awrs.reenrolment.registered_postcode.error.empty"),
       maxLengthValidation = null,
       formatValidations = invalidPostcodeErrorMessage
     ))

--- a/app/forms/reenrolment/RegisteredUrnForm.scala
+++ b/app/forms/reenrolment/RegisteredUrnForm.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package forms
+package forms.reenrolment
 
 import forms.prevalidation._
 import forms.validation.util.ConstraintUtil.{CompulsoryTextFieldMappingParameter, FieldFormatConstraintParameter, FieldMaxLengthConstraintParameter}
@@ -25,7 +25,7 @@ import play.api.data.Form
 import play.api.data.Forms._
 import play.api.data.validation.{Invalid, Valid}
 
-object AwrsEnrolmentUrnForm {
+object RegisteredUrnForm {
 
   val awrsUrn = "awrsUrn"
 

--- a/app/forms/reenrolment/RegisteredUtrForm.scala
+++ b/app/forms/reenrolment/RegisteredUtrForm.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package forms
+package forms.reenrolment
 
 import forms.prevalidation._
 import forms.validation.util.UTRValidator
@@ -22,20 +22,20 @@ import models.AwrsEnrolmentUtr
 import play.api.data.Form
 import play.api.data.Forms._
 
-object AwrsEnrolmentUtrForm {
+object RegisteredUtrForm {
 
   val utr = "utr"
 
   lazy val awrsEnrolmentUtrValidationForm: Form[AwrsEnrolmentUtr] = Form(mapping(
     utr ->  text
-      .verifying("awrs.utr.empty", x => {
+      .verifying("awrs.reenrolment.registered_utr.error.empty", x => {
         val trimmedString = x.replaceAll(" ", "")
         trimmedString.length > 0
       })
-      .verifying("awrs.utr.length", x => {
+      .verifying("awrs.reenrolment.registered_utr.error.length", x => {
         val trimmedString = x.replaceAll(" ", "")
         trimmedString.isEmpty || (trimmedString.nonEmpty && (trimmedString.matches("""^[0-9]{10}$""") || trimmedString.matches("""^[0-9]{13}$""")))})
-      .verifying("awrs.utr.invalidUTR", x => {
+      .verifying("awrs.reenrolment.registered_utr.error.invalidUTR", x => {
         val trimmedString = x.replaceAll(" ", "")
         trimmedString.isEmpty || !(trimmedString.matches("""^[0-9]{10}$""") || trimmedString.matches("""^[0-9]{13}$""")) || UTRValidator.validateUTR(trimmedString)
       })

--- a/app/models/FormModels.scala
+++ b/app/models/FormModels.scala
@@ -432,7 +432,6 @@ object Address {
   implicit val formats: OFormat[Address] = Json.format[Address]
 
   implicit class AddressUtil(address: Option[Address]) {
-    def toStringSeq: Seq[String] = address.fold(Seq[String]())(x => x.toStringSeq)
   }
 }
 

--- a/app/models/reenrolment/RegisteredPostcodeModel.scala
+++ b/app/models/reenrolment/RegisteredPostcodeModel.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package models
+package models.reenrolment
 
 import play.api.libs.json._
 

--- a/app/services/BusinessMatchingService.scala
+++ b/app/services/BusinessMatchingService.scala
@@ -21,6 +21,7 @@ import connectors.BusinessMatchingConnector
 import controllers.auth.StandardAuthRetrievals
 import forms.AWRSEnums
 import models._
+import models.reenrolment.AwrsRegisteredPostcode
 import play.api.libs.json.{JsSuccess, JsValue}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{LoggingUtils, SessionUtil}
@@ -77,7 +78,6 @@ class BusinessMatchingService @Inject()(keyStoreService: KeyStoreService,
       verifyPostCodeMatches(postCode.registeredPostcode, _)
     }
   }
-
 
   private def verifyPostCodeMatches(postcode: String, dataReturned: JsValue): Boolean = {
     val address = (dataReturned \ "address").validate[BCAddressApi3]

--- a/app/services/KeyStoreService.scala
+++ b/app/services/KeyStoreService.scala
@@ -19,6 +19,7 @@ package services
 import _root_.models._
 import connectors.{AwrsKeyStoreConnector, Save4LaterConnector}
 import controllers.auth.StandardAuthRetrievals
+import models.reenrolment.AwrsRegisteredPostcode
 import services.DataCacheKeys._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.cache.client.CacheMap

--- a/app/views/awrs_have_you_registered.scala.html
+++ b/app/views/awrs_have_you_registered.scala.html
@@ -39,7 +39,7 @@
     @backLink(controllers.routes.HaveYouRegisteredController.showLastLocation.url)
 }
 
-@awrsMain(title = s"${errorPrefix(haveYouRegisteredForm)} ${messages("awrs.generic.tab.title", messages("awrs.enrolment.have_you_registered.title"))}",
+@awrsMain(title = s"${errorPrefix(haveYouRegisteredForm)} ${messages("awrs.generic.tab.title", messages("awrs.have_you_registered.title"))}",
 backlink = Some(backlinkHtml), userLoggedIn = true){
 
     @if(haveYouRegisteredForm.errors.nonEmpty) {
@@ -48,7 +48,7 @@ backlink = Some(backlinkHtml), userLoggedIn = true){
 
     <header class = "page-header">
         <h1 id="have-you-registered-heading" class="govuk-heading-xl">
-            @messages("awrs.enrolment.have_you_registered.title")
+            @messages("awrs.have_you_registered.title")
         </h1>
     </header>
 
@@ -59,7 +59,7 @@ backlink = Some(backlinkHtml), userLoggedIn = true){
                     fieldset = Some(Fieldset(
                         legend = Some(Legend(
                             classes = "govuk-visually-hidden",
-                            content = Text(Messages("awrs.enrolment.have_you_registered.title"))
+                            content = Text(Messages("awrs.have_you_registered.title"))
                         ))
                     )),
                     items = Seq(

--- a/app/views/reenrolment/awrs_reenrolment_kickout.scala.html
+++ b/app/views/reenrolment/awrs_reenrolment_kickout.scala.html
@@ -32,29 +32,29 @@
 }
 
 @awrsMain(
-	title = messages("awrs.urn_kickout.title", messages("awrs.urn_kickout.title")),
+	title = messages("awrs.reenrolment.kickout.title", messages("awrs.reenrolment.kickout.title")),
 	backlink = Some(backlinkHtml),
 	userLoggedIn = true) {
 	<div>
 		<h1
 			id="awrs-kickout-title" class="govuk-heading-xl">
-			@messages("awrs.urn_kickout.title")
+			@messages("awrs.reenrolment.kickout.title")
 		</h1>
 		<h2 class="govuk-body">
-			@messages("awrs.urn_kickout.heading")
+			@messages("awrs.reenrolment.kickout.heading")
 		</h2>
 	
 		<p class="govuk-heading-s">
-			@messages("awrs.urn_kickout.p1")
+			@messages("awrs.reenrolment.kickout.p1")
 		</p>
 		<ul class="govuk-list govuk-list govuk-list">
-			<li>@messages("awrs.urn_kickout.p2")</li>
+			<li>@messages("awrs.reenrolment.kickout.p2")</li>
 			
-			<li>@messages("awrs.urn_kickout.p3")</li>
+			<li>@messages("awrs.reenrolment.kickout.p3")</li>
 			
-			<li>@messages("awrs.urn_kickout.p4")</li>
+			<li>@messages("awrs.reenrolment.kickout.p4")</li>
 			
-			<li>@messages("awrs.urn_kickout.p5")</li>
+			<li>@messages("awrs.reenrolment.kickout.p5")</li>
 		</ul>
 		
 		<hr class="govuk-section-break govuk-section-break--s govuk-section-break">
@@ -66,4 +66,3 @@
 		<hr class="govuk-section-break govuk-section-break--l govuk-section-break">
 	</div>
 }
-

--- a/app/views/reenrolment/awrs_registered_postcode.scala.html
+++ b/app/views/reenrolment/awrs_registered_postcode.scala.html
@@ -35,27 +35,27 @@ govukInput : GovukInput,
 govukButton : GovukButton,
 govukErrorSummary: GovukErrorSummary)
 
-@(postcodeForm: Form[models.AwrsRegisteredPostcode])(implicit request: Request[AnyRef], messages: Messages, applicationConfig: ApplicationConfig)
+@(postcodeForm: Form[models.reenrolment.AwrsRegisteredPostcode])(implicit request: Request[AnyRef], messages: Messages, applicationConfig: ApplicationConfig)
 @backlinkHtml = {
-    @backLink(controllers.routes.AwrsUrnController.showArwsUrnPage.url)
+    @backLink(controllers.reenrolment.routes.RegisteredUrnController.showArwsUrnPage.url)
 }
 
-@awrsMain( title = s"${errorPrefix(postcodeForm)} ${messages("awrs.generic.tab.title", messages("awrs.register_postcode.title"))}", backlink = Some(backlinkHtml)) {
+@awrsMain( title = s"${errorPrefix(postcodeForm)} ${messages("awrs.generic.tab.title", messages("awrs.reenrolment.registered_postcode.title"))}", backlink = Some(backlinkHtml)) {
 
     @if(postcodeForm.errors.nonEmpty) {
        @govukErrorSummary(ErrorSummary().withFormErrorsAsText(postcodeForm))
     }
-    @formWithCSRF(action = controllers.routes.AwrsRegisteredPostcodeController.saveAndContinue){
+    @formWithCSRF(action = controllers.reenrolment.routes.RegisteredPostcodeController.saveAndContinue){
 
 
         @govukInput(Input(
         label = Label(
         isPageHeading = true,
         classes = "govuk-label--xl",
-        content = Text(messages("awrs.register_postcode.heading")),
+        content = Text(messages("awrs.reenrolment.registered_postcode.heading")),
         ),
         hint = Some(Hint(
-        content = Text(messages("awrs.register_postcode.hint"))
+        content = Text(messages("awrs.reenrolment.registered_postcode.hint"))
         )),
         autocomplete = Some("postal-code")
         ).withFormField(postcodeForm("registeredPostcode")))

--- a/app/views/reenrolment/awrs_registered_urn.scala.html
+++ b/app/views/reenrolment/awrs_registered_urn.scala.html
@@ -28,7 +28,7 @@
 
 @(awrsUrnForm: Form[models.AwrsEnrolmentUrn])(implicit request: Request[AnyRef], messages: Messages, applicationConfig: ApplicationConfig)
 
-@headerTitleName = @{"awrs.urn.title"}
+@headerTitleName = @{"awrs.reenrolment.registered_urn.title"}
 
 @backlinkHtml = {
     @backLink(controllers.routes.HaveYouRegisteredController.showHaveYouRegisteredPage.url)
@@ -47,13 +47,13 @@
         <h1 id="awrsUrn-heading" class="govuk-heading-xl">@messages(headerTitleName)</h1>
     </header>
 
-    @formWithCSRF(action = controllers.routes.AwrsUrnController.saveAndContinue) {
+    @formWithCSRF(action = controllers.reenrolment.routes.RegisteredUrnController.saveAndContinue) {
 
         @govukInput(
             Input(
                 label = Label(
                     classes = "govuk-label",
-                    content = Text(Messages("awrs.urn.label"))
+                    content = Text(Messages("awrs.reenrolment.registered_urn.label"))
                 )
             ).withFormField(awrsUrnForm("awrsUrn"))
         )

--- a/app/views/reenrolment/awrs_registered_utr.scala.html
+++ b/app/views/reenrolment/awrs_registered_utr.scala.html
@@ -30,14 +30,14 @@
 
 @headerTitleName =  @{
     if(isSA) {
-        "awrs.utr.title.sa"
+        "awrs.reenrolment.registered_utr.title.sa"
     } else {
-        "awrs.utr.title.ct"
+        "awrs.reenrolment.registered_utr.title.ct"
     }
 }
 
 @backlinkHtml = {
-    @backLink(controllers.routes.AwrsRegisteredPostcodeController.showPostCode.url)
+    @backLink(controllers.reenrolment.routes.RegisteredPostcodeController.showPostCode.url)
 }
 
 @awrsMain(
@@ -53,13 +53,13 @@
         <h1 id="awrsUtr-heading" class="govuk-heading-xl">@messages(headerTitleName)</h1>
     </header>
 
-    @formWithCSRF(action = controllers.routes.AwrsUtrController.saveAndContinue) {
+    @formWithCSRF(action = controllers.reenrolment.routes.RegisteredUtrController.saveAndContinue) {
 
         @govukInput(
             Input(
                 label = Label(
                     classes = "govuk-label",
-                    content = Text(Messages("awrs.utr.label"))
+                    content = Text(Messages("awrs.reenrolment.registered_utr.label"))
                 )
             ).withFormField(awrsUtrForm("utr"))
         )

--- a/app/views/reenrolment/awrs_successful_enrolment.scala.html
+++ b/app/views/reenrolment/awrs_successful_enrolment.scala.html
@@ -22,17 +22,17 @@
 
 @()(implicit request: Request[AnyRef], messages: Messages, applicationConfig: ApplicationConfig)
 
-@awrsMain(title = messages("awrs.successful_enrolment.title", messages("awrs.successful_enrolment.title"))) {
+@awrsMain(title = messages("awrs.reenrolment.successful_enrolment.title", messages("awrs.reenrolment.successful_enrolment.title"))) {
 <div class="govuk-panel govuk-panel--confirmation">
 	<h1 class="govuk-panel__title">
-		@Messages("awrs.successful_enrolment.title")
+		@Messages("awrs.reenrolment.successful_enrolment.title")
 	</h1>
 </div>
 	<h2 class="govuk-body govuk-!-font-weight-bold">
-		@messages("awrs.successful_enrolment.heading")
+		@messages("awrs.reenrolment.successful_enrolment.heading")
 	</h2>
 <p class="govuk-body" id="paragraph-1">
-	@messages("awrs.successful_enrolment.p1")
+	@messages("awrs.reenrolment.successful_enrolment.p1")
 </p>
 <p class="govuk-body" id="paragraph-2">
 	More detailed information can be found in the
@@ -43,7 +43,7 @@
 <br>
 <br>
 	<a href="@applicationConfig.businessTaxAccountPage" role="button" class="govuk-button" id = "bta-redirect-button" data-module="govuk-button">
-		@messages("awrs.successful_enrolment.btn")
+		@messages("awrs.reenrolment.successful_enrolment.btn")
 	</a>
 <br>
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,7 +3,6 @@
 
 GET         /assets/*file                                   controllers.Assets.versioned(path="/public", file: Asset)
 
-
 GET         /                                               controllers.HomeController.showOrRedirect(callerId: Option[String])
 # Leaving in landing-page route in case people have it bookmarked
 GET         /landing-page                                   controllers.HomeController.showOrRedirect(callerId: Option[String])
@@ -23,11 +22,6 @@ GET         /keep-alive                                     controllers.Applicat
 GET         /wrong-account                                  controllers.WrongAccountController.showWrongAccountPage(businessName: Option[String])
 
 GET         /unauthorised                                   controllers.IndexController.unauthorised
-
-GET         /urn                                            controllers.AwrsUrnController.showArwsUrnPage
-POST        /urn/saveAndReturn                              controllers.AwrsUrnController.saveAndContinue
-GET         /utr                                            controllers.AwrsUtrController.showArwsUtrPage
-POST        /utr/saveAndReturn                              controllers.AwrsUtrController.saveAndContinue
 
 GET         /additional-premises                            controllers.AdditionalPremisesController.showPremisePage(id: Int ?= 1, isLinearMode: Boolean = true, isNewRecord: Boolean = true)
 GET         /additional-premises/delete                     controllers.AdditionalPremisesController.showDelete(id: Int ?= 1)
@@ -164,15 +158,20 @@ GET         /signed-out                                     controllers.Applicat
 GET         /re-apply                                       controllers.ReapplicationController.show
 POST        /re-apply                                       controllers.ReapplicationController.submit
 
-#
 GET        /have-you-registered                             controllers.HaveYouRegisteredController.showHaveYouRegisteredPage
 POST       /have-you-registered/confirm                     controllers.HaveYouRegisteredController.saveAndContinue
 GET        /have-you-registered/lastLocation                controllers.HaveYouRegisteredController.showLastLocation
 
-GET         /urn-kickout                                    controllers.AwrsUrnKickoutController.showURNKickOutPage
+# Reenrolment journey
+GET         /reenrolment/registered-urn                     controllers.reenrolment.RegisteredUrnController.showArwsUrnPage
+POST        /reenrolment/registered-urn/saveAndReturn       controllers.reenrolment.RegisteredUrnController.saveAndContinue
 
-GET         /registered-postcode                            controllers.AwrsRegisteredPostcodeController.showPostCode
-POST        /registered-postcode                            controllers.AwrsRegisteredPostcodeController.saveAndContinue
+GET         /reenrolment/registered-postcode                controllers.reenrolment.RegisteredPostcodeController.showPostCode
+POST        /reenrolment/registered-postcode                controllers.reenrolment.RegisteredPostcodeController.saveAndContinue
 
-# DL-14749
-GET         /successful-enrolment                           controllers.SuccessfulEnrolmentController.showSuccessfulEnrolmentPage
+GET         /reenrolment/registered-utr                     controllers.reenrolment.RegisteredUtrController.showArwsUtrPage
+POST        /registered-utr/saveAndReturn                   controllers.reenrolment.RegisteredUtrController.saveAndContinue
+
+GET         /reenrolment/kickout                            controllers.reenrolment.KickoutController.showURNKickOutPage
+
+GET         /reenrolment/successful-enrolment               controllers.reenrolment.SuccessfulEnrolmentController.showSuccessfulEnrolmentPage

--- a/conf/messages
+++ b/conf/messages
@@ -956,41 +956,41 @@ awrs.application_timeout.sign_in_btn = Sign in
 
 # Enrolment Journey Pages
 #===========================
-awrs.enrolment.have_you_registered.title = Have you registered with the Alcohol Wholesaler Registration Scheme (AWRS)?
-awrs.enrolment.have_you_registered.error = You must select either Yes or No
+awrs.have_you_registered.title = Have you registered with the Alcohol Wholesaler Registration Scheme (AWRS)?
+awrs.have_you_registered.error = You must select either Yes or No
 
 # URN Messages
 #===========================
-awrs.urn.title = What is your Alcohol Wholesaler Registration Scheme (AWRS) Unique Reference Number (URN)?
-awrs.urn.label = Your URN is 4 letters and 11 numbers, like XXAW00000123456. You can find it printed on the wholesaler or producer’s invoices. If you can’t find it, contact the wholesaler or producer for the URN.
+awrs.reenrolment.registered_urn.title = What is your Alcohol Wholesaler Registration Scheme (AWRS) Unique Reference Number (URN)?
+awrs.reenrolment.registered_urn.label = Your URN is 4 letters and 11 numbers, like XXAW00000123456. You can find it printed on the wholesaler or producer’s invoices. If you can’t find it, contact the wholesaler or producer for the URN.
 
 # UTR Messages
 #===========================
-awrs.utr.title.ct = Enter your Corporation Tax Unique Taxpayer Reference (UTR)
-awrs.utr.title.sa = Enter your Self Assessment Tax Unique Taxpayer Reference (UTR)
-awrs.utr.label = Your Unique Taxpayer Reference (UTR) is 10 or 13 digits long. You can find it in your Personal Tax Account, the HMRC app, or on tax returns and other letters about Corporation Tax. It might be called ‘reference’, ‘UTR’, or ‘official use’.
-awrs.utr.empty = Enter your 10 or 13 digit Unique Taxpayer Reference (UTR)
-awrs.utr.length = The Unique Taxpayer Reference (UTR) must be 10 or 13 digits long
-awrs.utr.invalidUTR = The Unique Taxpayer Reference (UTR) is not valid
+awrs.reenrolment.registered_utr.title.ct = Enter your Corporation Tax Unique Taxpayer Reference (UTR)
+awrs.reenrolment.registered_utr.title.sa = Enter your Self Assessment Tax Unique Taxpayer Reference (UTR)
+awrs.reenrolment.registered_utr.label = Your Unique Taxpayer Reference (UTR) is 10 or 13 digits long. You can find it in your Personal Tax Account, the HMRC app, or on tax returns and other letters about Corporation Tax. It might be called ‘reference’, ‘UTR’, or ‘official use’.
+awrs.reenrolment.registered_utr.error.empty = Enter your 10 or 13 digit Unique Taxpayer Reference (UTR)
+awrs.reenrolment.registered_utr.error.length = The Unique Taxpayer Reference (UTR) must be 10 or 13 digits long
+awrs.reenrolment.registered_utr.error.invalidUTR = The Unique Taxpayer Reference (UTR) is not valid
 
 # Awrs registered postcode
-awrs.register_postcode.title = Enter the postcode you registered with Alcohol Wholesaler Registration Scheme (AWRS)
-awrs.register_postcode.heading = Enter the postcode you registered with Alcohol Wholesaler Registration Scheme (AWRS)
-awrs.register_postcode.error.empty = Enter your postcode
-awrs.register_postcode.error.invalid_postcode = Enter a valid UK postcode
-awrs.register_postcode.hint = For example, SW1A 2AA
+#===========================
+awrs.reenrolment.registered_postcode.title = Enter the postcode you registered with Alcohol Wholesaler Registration Scheme (AWRS)
+awrs.reenrolment.registered_postcode.heading = Enter the postcode you registered with Alcohol Wholesaler Registration Scheme (AWRS)
+awrs.reenrolment.registered_postcode.hint = For example, SW1A 2AA
+awrs.reenrolment.registered_postcode.error.empty = Enter your postcode
+awrs.reenrolment.registered_postcode.error.invalid_postcode = Enter a valid UK postcode
 
-awrs.urn_kickout.title = Get Help with your AWRS registration
-awrs.urn_kickout.heading = We're unable to locate your details linked with the Unique Reference Number (URN) you entered.
-awrs.urn_kickout.p1 = Contact HMRC
-awrs.urn_kickout.p2 = Phone: 0300 200 3700
-awrs.urn_kickout.p3 = Textphone: 0300 200 3719
-awrs.urn_kickout.p4 = Outside UK: +44 2920 501 261
-awrs.urn_kickout.p5 = Monday to Friday, 9am to 6pm (except public holidays)
+awrs.reenrolment.kickout.title = Get Help with your AWRS registration
+awrs.reenrolment.kickout.heading = We're unable to locate your details linked with the Unique Reference Number (URN) you entered.
+awrs.reenrolment.kickout.p1 = Contact HMRC
+awrs.reenrolment.kickout.p2 = Phone: 0300 200 3700
+awrs.reenrolment.kickout.p3 = Textphone: 0300 200 3719
+awrs.reenrolment.kickout.p4 = Outside UK: +44 2920 501 261
+awrs.reenrolment.kickout.p5 = Monday to Friday, 9am to 6pm (except public holidays)
 
-awrs.successful_enrolment.title = You have added your AWRS to your business tax account
-awrs.successful_enrolment.heading = What happens next
-awrs.successful_enrolment.p1 = You can now view and manage your AWRS registration in your business tax account.
-awrs.successful_enrolment.p2 = More detailed information can be found in the AWRS guidance (opens in a new tab)
-awrs.successful_enrolment.btn = View your business tax account
-
+awrs.reenrolment.successful_enrolment.title = You have added your AWRS to your business tax account
+awrs.reenrolment.successful_enrolment.heading = What happens next
+awrs.reenrolment.successful_enrolment.p1 = You can now view and manage your AWRS registration in your business tax account.
+awrs.reenrolment.successful_enrolment.p2 = More detailed information can be found in the AWRS guidance (opens in a new tab)
+awrs.reenrolment.successful_enrolment.btn = View your business tax account

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -26,18 +26,18 @@ private object AppDependencies {
     "uk.gov.hmrc"                   %% "http-caching-client-play-30" % "12.1.0",
     "uk.gov.hmrc"                   %% "bootstrap-frontend-play-30"  % bootstrapPlayVersion,
     "uk.gov.hmrc"                   %% "play-partials-play-30"       % "10.0.0", // includes code for retrieving partials, e.g. the Help with this page form
-    "uk.gov.hmrc"                   %% "domain-play-30"              % "11.0.0",
     "com.yahoo.platform.yui"        %  "yuicompressor"               % "2.4.8",
-    "uk.gov.hmrc"                   %% "play-frontend-hmrc-play-30"  % "12.0.0",
+    "uk.gov.hmrc"                   %% "play-frontend-hmrc-play-30"  % "12.1.0",
     "commons-codec"                 %  "commons-codec"               % "1.18.0",
     "com.googlecode.htmlcompressor" %  "htmlcompressor"              % "1.5.2"
   )
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-test-play-30"  % bootstrapPlayVersion % Test,
-    "org.jsoup"         %  "jsoup"                   % "1.19.1"             % Test,
+    "org.jsoup"         %  "jsoup"                   % "1.20.1"             % Test,
     "org.mockito"       %  "mockito-core"            % "5.17.0"             % Test,
-    "org.scalatestplus" %% "mockito-5-12"            % "3.2.19.0"           % Test
+    "org.scalatestplus" %% "mockito-5-12"            % "3.2.19.0"           % Test,
+    "uk.gov.hmrc"       %% "domain-play-30"          % "11.0.0"             % Test
   )
 
   val itDependencies: Seq[ModuleID] = Seq()

--- a/test/controllers/HaveYouRegisteredControllerTest.scala
+++ b/test/controllers/HaveYouRegisteredControllerTest.scala
@@ -95,7 +95,7 @@ class HaveYouRegisteredControllerTest extends AwrsUnitTestTraits with ServicesUn
       val result: Future[Result] = mockHaveYouRegisteredController.saveAndContinue().apply(testRequest(Some(true)))
 
       status(result) mustBe SEE_OTHER
-      redirectLocation(result) mustBe Some(controllers.routes.AwrsUrnController.showArwsUrnPage.url)
+      redirectLocation(result) mustBe Some(controllers.reenrolment.routes.RegisteredUrnController.showArwsUrnPage.url)
     }
   }
 

--- a/test/controllers/reenrolment/KickoutControllerTest.scala
+++ b/test/controllers/reenrolment/KickoutControllerTest.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers
+package controllers.reenrolment
 
 import builders.SessionBuilder
 import play.api.mvc.AnyContentAsEmpty
@@ -22,15 +22,15 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.ServicesUnitTestFixture
 import utils.AwrsUnitTestTraits
-import views.html.urn_kickout
+import views.html.reenrolment.awrs_reenrolment_kickout
 
-class AwrsUrnKickoutControllerTest extends AwrsUnitTestTraits
+class KickoutControllerTest extends AwrsUnitTestTraits
   with ServicesUnitTestFixture {
 
   val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
-  val template: urn_kickout = app.injector.instanceOf[views.html.urn_kickout]
+  val template: awrs_reenrolment_kickout = app.injector.instanceOf[views.html.reenrolment.awrs_reenrolment_kickout]
 
-  val testURNKickOutController: AwrsUrnKickoutController = new AwrsUrnKickoutController(
+  val testURNKickOutController: KickoutController = new KickoutController(
     mockMCC,
     mockAppConfig,
     mockAwrsFeatureSwitches,
@@ -41,20 +41,19 @@ class AwrsUrnKickoutControllerTest extends AwrsUnitTestTraits
     template
   )
 
-  "URNKickOutController" must {
+  "KickOutController" must {
 
-    "show the Kickout page when enrolmentJourney is enable" in {
+    "show the Kickout page when enrolmentJourney is enabled" in {
       setAuthMocks()
       setupEnrolmentJourneyFeatureSwitchMock(true)
       val res = testURNKickOutController.showURNKickOutPage().apply(SessionBuilder.buildRequestWithSession(userId))
       status(res) mustBe 200
     }
-    "return 404 the Kickout page when enrolmentJourney is ldisable" in {
+    "return 404 when enrolmentJourney is disabled" in {
       setAuthMocks()
       setupEnrolmentJourneyFeatureSwitchMock(false)
       val res = testURNKickOutController.showURNKickOutPage().apply(SessionBuilder.buildRequestWithSession(userId))
       status(res) mustBe 404
     }
   }
-
 }

--- a/test/controllers/reenrolment/RegisteredPostCodeControllerTest.scala
+++ b/test/controllers/reenrolment/RegisteredPostCodeControllerTest.scala
@@ -14,33 +14,33 @@
  * limitations under the License.
  */
 
-package controllers
+package controllers.reenrolment
 
 import builders.SessionBuilder
 import connectors.mock.MockAuthConnector
-import forms.AwrsRegisteredPostcodeForm
-import models.AwrsRegisteredPostcode
+import forms.reenrolment.RegisteredPostcodeForm
+import models.reenrolment.AwrsRegisteredPostcode
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.ServicesUnitTestFixture
 import services.mocks.{MockIndexService, MockKeyStoreService}
 import utils.{AwrsUnitTestTraits, TestUtil}
-import views.html.awrs_registered_postcode
+import views.html.reenrolment.awrs_registered_postcode
 
-class AwrsRegisteredPostCodeControllerTest extends AwrsUnitTestTraits
+class RegisteredPostCodeControllerTest extends AwrsUnitTestTraits
   with ServicesUnitTestFixture with MockAuthConnector
   with MockKeyStoreService
   with MockIndexService {
 
   def testRequest(answer: String): FakeRequest[AnyContentAsFormUrlEncoded] =
-    TestUtil.populateFakeRequest[AwrsRegisteredPostcode](FakeRequest(), AwrsRegisteredPostcodeForm.awrsRegisteredPostcodeForm.form, AwrsRegisteredPostcode(answer))
+    TestUtil.populateFakeRequest[AwrsRegisteredPostcode](FakeRequest(), RegisteredPostcodeForm.awrsRegisteredPostcodeForm.form, AwrsRegisteredPostcode(answer))
 
   val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
 
-  val template: awrs_registered_postcode = app.injector.instanceOf[views.html.awrs_registered_postcode]
+  val template: awrs_registered_postcode = app.injector.instanceOf[views.html.reenrolment.awrs_registered_postcode]
 
-  val testAwrsRegisteredPostcodeController: AwrsRegisteredPostcodeController = new AwrsRegisteredPostcodeController(mockMCC, mockAppConfig, mockAuthConnector,
+  val testAwrsRegisteredPostcodeController: RegisteredPostcodeController = new RegisteredPostcodeController(mockMCC, mockAppConfig, mockAuthConnector,
     mockAccountUtils, mockDeEnrolService, mockAuditable ,mockAwrsFeatureSwitches,testKeyStoreService, template)
 
   "AwrsPostcodeController" must {

--- a/test/controllers/reenrolment/RegisteredUrnControllerTest.scala
+++ b/test/controllers/reenrolment/RegisteredUrnControllerTest.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package controllers
+package controllers.reenrolment
 
 import builders.SessionBuilder
 import connectors.mock.MockAuthConnector
-import forms.AwrsEnrolmentUrnForm
+import forms.reenrolment.RegisteredUrnForm
 import models.AwrsStatus.Approved
 import models.{AwrsEnrolmentUrn, Business, Info, SearchResult}
 import org.mockito.ArgumentMatchers
@@ -31,18 +31,18 @@ import services.ServicesUnitTestFixture
 import services.mocks.{MockIndexService, MockKeyStoreService}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{AwrsUnitTestTraits, TestUtil}
-import views.html.awrs_urn
+import views.html.reenrolment.awrs_registered_urn
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class AwrsUrnControllerTest extends AwrsUnitTestTraits
+class RegisteredUrnControllerTest extends AwrsUnitTestTraits
   with ServicesUnitTestFixture with MockAuthConnector
   with MockKeyStoreService
   with MockIndexService {
 
   def testRequest(answer: String): FakeRequest[AnyContentAsFormUrlEncoded] =
-    TestUtil.populateFakeRequest[AwrsEnrolmentUrn](FakeRequest(), AwrsEnrolmentUrnForm.awrsEnrolmentUrnForm.form, AwrsEnrolmentUrn(answer))
+    TestUtil.populateFakeRequest[AwrsEnrolmentUrn](FakeRequest(), RegisteredUrnForm.awrsEnrolmentUrnForm.form, AwrsEnrolmentUrn(answer))
 
   def testSearchResult(ref:String) = SearchResult(List(
     Business(ref,
@@ -51,9 +51,9 @@ class AwrsUrnControllerTest extends AwrsUnitTestTraits
       Info(Some("Business Name"), Some("Trading Name"), Some("Full name"), None),
       None)))
   val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
-  val template: awrs_urn = app.injector.instanceOf[views.html.awrs_urn]
+  val template: awrs_registered_urn = app.injector.instanceOf[views.html.reenrolment.awrs_registered_urn]
 
-  val testAwrsUrnController: AwrsUrnController = new AwrsUrnController(mockMCC,
+  val testAwrsUrnController: RegisteredUrnController = new RegisteredUrnController(mockMCC,
     testKeyStoreService, mockDeEnrolService, mockAuthConnector,
     mockAuditable, mockAccountUtils, testLookupService, mockAwrsFeatureSwitches, mockAppConfig, template)
 

--- a/test/controllers/reenrolment/SuccessfulEnrolmentControllerTest.scala
+++ b/test/controllers/reenrolment/SuccessfulEnrolmentControllerTest.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers
+package controllers.reenrolment
 
 import builders.SessionBuilder
 import play.api.mvc.AnyContentAsEmpty
@@ -22,12 +22,12 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.ServicesUnitTestFixture
 import utils.AwrsUnitTestTraits
-import views.html.awrs_successful_enrolment
+import views.html.reenrolment.awrs_successful_enrolment
 
 class SuccessfulEnrolmentControllerTest extends AwrsUnitTestTraits
   with ServicesUnitTestFixture {
   val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
-  val template: awrs_successful_enrolment = app.injector.instanceOf[views.html.awrs_successful_enrolment]
+  val template: awrs_successful_enrolment = app.injector.instanceOf[views.html.reenrolment.awrs_successful_enrolment]
   val testSuccessfulEnrolmentController: SuccessfulEnrolmentController = new SuccessfulEnrolmentController(
     mockMCC,
     mockAppConfig,

--- a/test/forms/HaveYouRegisteredFormTest.scala
+++ b/test/forms/HaveYouRegisteredFormTest.scala
@@ -35,7 +35,7 @@ class HaveYouRegisteredFormTest extends PlaySpec with MockitoSugar with BeforeAn
       form.bind(Map(fieldId -> "")).fold(
         formWithErrors => {
           formWithErrors(fieldId).errors.size mustBe 1
-          formWithErrors(fieldId).errors.head.message mustBe "awrs.enrolment.have_you_registered.error"
+          formWithErrors(fieldId).errors.head.message mustBe "awrs.have_you_registered.error"
         },
         _ => fail("Field should contain errors")
       )

--- a/test/forms/reenrolment/RegisteredPostcodeFormTest.scala
+++ b/test/forms/reenrolment/RegisteredPostcodeFormTest.scala
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package forms
+package forms.reenrolment
 
 import forms.test.util._
-import models.AwrsRegisteredPostcode
+import models.reenrolment.AwrsRegisteredPostcode
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.data.Form
 import utils.AwrsFieldConfig
 
-class AwrsRegisteredPostcodeFormTest extends PlaySpec with MockitoSugar  with AwrsFieldConfig with AwrsFormTestUtils {
+class RegisteredPostcodeFormTest extends PlaySpec with MockitoSugar  with AwrsFieldConfig with AwrsFormTestUtils {
 
-  implicit lazy val form: Form[AwrsRegisteredPostcode] = AwrsRegisteredPostcodeForm.awrsRegisteredPostcodeForm.form
+  implicit lazy val form: Form[AwrsRegisteredPostcode] = RegisteredPostcodeForm.awrsRegisteredPostcodeForm.form
 
   "Postcode form validation" must {
 
@@ -35,7 +35,7 @@ class AwrsRegisteredPostcodeFormTest extends PlaySpec with MockitoSugar  with Aw
       form.bind(Map(fieldId -> "")).fold(
         formWithErrors => {
           formWithErrors(fieldId).errors.size mustBe 1
-          formWithErrors(fieldId).errors.head.message mustBe "awrs.register_postcode.error.empty"
+          formWithErrors(fieldId).errors.head.message mustBe "awrs.reenrolment.registered_postcode.error.empty"
         },
         _ => fail("Field should contain errors")
       )
@@ -45,7 +45,7 @@ class AwrsRegisteredPostcodeFormTest extends PlaySpec with MockitoSugar  with Aw
       form.bind(Map(fieldId -> "test")).fold(
         formWithErrors => {
           formWithErrors(fieldId).errors.size mustBe 1
-          formWithErrors(fieldId).errors.head.message mustBe "awrs.register_postcode.error.invalid_postcode"
+          formWithErrors(fieldId).errors.head.message mustBe "awrs.reenrolment.registered_postcode.error.invalid_postcode"
         },
         _ => fail("Field should contain errors")
       )
@@ -55,7 +55,7 @@ class AwrsRegisteredPostcodeFormTest extends PlaySpec with MockitoSugar  with Aw
       form.bind(Map(fieldId -> "1111ne")).fold(
         formWithErrors => {
           formWithErrors(fieldId).errors.size mustBe 1
-          formWithErrors(fieldId).errors.head.message mustBe "awrs.register_postcode.error.invalid_postcode"
+          formWithErrors(fieldId).errors.head.message mustBe "awrs.reenrolment.registered_postcode.error.invalid_postcode"
         },
         _ => fail("Field should contain errors")
       )
@@ -93,7 +93,7 @@ class AwrsRegisteredPostcodeFormTest extends PlaySpec with MockitoSugar  with Aw
       form.bind(Map(fieldId -> "NE27&0JZ")).fold(
         formWithErrors => {
           formWithErrors(fieldId).errors.size mustBe 1
-          formWithErrors(fieldId).errors.head.message mustBe "awrs.register_postcode.error.invalid_postcode"
+          formWithErrors(fieldId).errors.head.message mustBe "awrs.reenrolment.registered_postcode.error.invalid_postcode"
         },
         _ => fail("Field should contain errors")
       )

--- a/test/forms/reenrolment/RegisteredUrnFormTest.scala
+++ b/test/forms/reenrolment/RegisteredUrnFormTest.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package forms
+package forms.reenrolment
 
-import forms.AwrsEnrolmentUrnForm.{awrsEnrolmentUrnForm, awrsUrn, maxQueryLength}
+import forms.reenrolment.RegisteredUrnForm.{awrsEnrolmentUrnForm, awrsUrn, maxQueryLength}
 import forms.test.util.AwrsFormTestUtils
 import models.AwrsEnrolmentUrn
 import org.scalatestplus.play.PlaySpec
 import play.api.data.Form
 
-class AwrsEnrolmentUrnFormTest extends PlaySpec  with AwrsFormTestUtils {
+class RegisteredUrnFormTest extends PlaySpec  with AwrsFormTestUtils {
 
   "AwrsEnrolmentUrnForm" should {
     implicit val form: Form[AwrsEnrolmentUrn] = awrsEnrolmentUrnForm.form

--- a/test/forms/reenrolment/RegisteredUtrFormTest.scala
+++ b/test/forms/reenrolment/RegisteredUtrFormTest.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package forms
+package forms.reenrolment
 
-import forms.AwrsEnrolmentUtrForm.{awrsEnrolmentUtrForm, utr}
+import forms.reenrolment.RegisteredUtrForm.{awrsEnrolmentUtrForm, utr}
 import forms.test.util.AwrsFormTestUtils
 import models.AwrsEnrolmentUtr
 import org.scalatestplus.play.PlaySpec
 import play.api.data.Form
 
-class AwrsEnrolmentUtrFormTest extends PlaySpec with AwrsFormTestUtils {
+class RegisteredUtrFormTest extends PlaySpec with AwrsFormTestUtils {
 
   "AwrsEnrolmentUtrForm" should {
     implicit val form: Form[AwrsEnrolmentUtr] = awrsEnrolmentUtrForm.form
@@ -34,7 +34,7 @@ class AwrsEnrolmentUtrFormTest extends PlaySpec with AwrsFormTestUtils {
       form.bind(Map(fieldId -> "")).fold(
         formWithErrors => {
           formWithErrors(fieldId).errors.size mustBe 1
-          formWithErrors(fieldId).errors.head.message mustBe "awrs.utr.empty"
+          formWithErrors(fieldId).errors.head.message mustBe "awrs.reenrolment.registered_utr.error.empty"
         },
         _ => fail("Field should contain errors")
       )
@@ -45,7 +45,7 @@ class AwrsEnrolmentUtrFormTest extends PlaySpec with AwrsFormTestUtils {
       form.bind(Map(fieldId -> "623211381456")).fold(
         formWithErrors => {
           formWithErrors(fieldId).errors.size mustBe 1
-          messages(formWithErrors(fieldId).errors.head.message) mustBe messages("awrs.utr.length", fieldNameInErrorMessage)
+          messages(formWithErrors(fieldId).errors.head.message) mustBe messages("awrs.reenrolment.registered_utr.error.length", fieldNameInErrorMessage)
         },
         _ => fail("Field should contain errors")
       )
@@ -55,7 +55,7 @@ class AwrsEnrolmentUtrFormTest extends PlaySpec with AwrsFormTestUtils {
       form.bind(Map(fieldId -> "       ")).fold(
         formWithErrors => {
           formWithErrors(fieldId).errors.size mustBe 1
-          messages(formWithErrors(fieldId).errors.head.message) mustBe messages("awrs.utr.empty", fieldNameInErrorMessage)
+          messages(formWithErrors(fieldId).errors.head.message) mustBe messages("awrs.reenrolment.registered_utr.error.empty", fieldNameInErrorMessage)
         },
         _ => fail("Field should contain errors")
       )
@@ -65,7 +65,7 @@ class AwrsEnrolmentUtrFormTest extends PlaySpec with AwrsFormTestUtils {
       form.bind(Map(fieldId -> "623211")).fold(
         formWithErrors => {
           formWithErrors(fieldId).errors.size mustBe 1
-          messages(formWithErrors(fieldId).errors.head.message) mustBe messages("awrs.utr.length", fieldNameInErrorMessage)
+          messages(formWithErrors(fieldId).errors.head.message) mustBe messages("awrs.reenrolment.registered_utr.error.length", fieldNameInErrorMessage)
         },
         _ => fail("Field should contain errors")
       )
@@ -76,7 +76,7 @@ class AwrsEnrolmentUtrFormTest extends PlaySpec with AwrsFormTestUtils {
       form.bind(Map(fieldId -> "6232113818073")).fold(
         formWithErrors => {
           formWithErrors(fieldId).errors.size mustBe 1
-          messages(formWithErrors(fieldId).errors.head.message) mustBe messages("awrs.utr.invalidUTR", fieldNameInErrorMessage)
+          messages(formWithErrors(fieldId).errors.head.message) mustBe messages("awrs.reenrolment.registered_utr.error.invalidUTR", fieldNameInErrorMessage)
         },
         _ => fail("Field should contain errors")
       )

--- a/test/models/AwrsRegisteredPostcodeModelTest.scala
+++ b/test/models/AwrsRegisteredPostcodeModelTest.scala
@@ -16,6 +16,7 @@
 
 package models
 
+import models.reenrolment.AwrsRegisteredPostcode
 import org.scalatestplus.play.PlaySpec
 
 class AwrsRegisteredPostcodeModelTest extends PlaySpec {

--- a/test/services/BusinessMatchingServiceTest.scala
+++ b/test/services/BusinessMatchingServiceTest.scala
@@ -19,6 +19,7 @@ package services
 import connectors._
 import forms.AWRSEnums
 import models._
+import models.reenrolment.AwrsRegisteredPostcode
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when

--- a/test/services/mocks/MockKeyStoreService.scala
+++ b/test/services/mocks/MockKeyStoreService.scala
@@ -17,6 +17,7 @@
 package services.mocks
 
 import connectors.mock.MockKeyStoreConnector
+import models.reenrolment.AwrsRegisteredPostcode
 import models.{StatusNotification, _}
 import org.mockito.Mockito._
 import org.mockito.{AdditionalMatchers, ArgumentMatchers}

--- a/test/views/reenrolment/KickOutViewTest.scala
+++ b/test/views/reenrolment/KickOutViewTest.scala
@@ -25,10 +25,11 @@ class KickOutViewTest extends ViewTestFixture {
   val view: awrs_reenrolment_kickout = app.injector.instanceOf[views.html.reenrolment.awrs_reenrolment_kickout]
   override val htmlContent: HtmlFormat.Appendable = view.apply()(fakeRequest, messages, mockAppConfig)
 
-  "kickout page" should {
-    "render the correct content" in {
-      heading mustBe "Get Help with your AWRS registration"
-      bodyText mustBe "Contact HMRC"
+  "The kickout page" should {
+    "render the content correctly" in {
+
+      heading mustBe messages("awrs.reenrolment.kickout.title")
+      bodyText mustBe messages("awrs.reenrolment.kickout.p1")
     }
   }
 }

--- a/test/views/reenrolment/KickOutViewTest.scala
+++ b/test/views/reenrolment/KickOutViewTest.scala
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-package views
+package views.reenrolment
 
 import play.twirl.api.HtmlFormat
-import views.html.urn_kickout
+import views.ViewTestFixture
+import views.html.reenrolment.awrs_reenrolment_kickout
 
-class URN_KickOutTest extends ViewTestFixture {
+class KickOutViewTest extends ViewTestFixture {
 
-  val view: urn_kickout = app.injector.instanceOf[views.html.urn_kickout]
+  val view: awrs_reenrolment_kickout = app.injector.instanceOf[views.html.reenrolment.awrs_reenrolment_kickout]
   override val htmlContent: HtmlFormat.Appendable = view.apply()(fakeRequest, messages, mockAppConfig)
 
-  "urn kickout page" should {
+  "kickout page" should {
     "render the correct content" in {
       heading mustBe "Get Help with your AWRS registration"
       bodyText mustBe "Contact HMRC"

--- a/test/views/reenrolment/RegisteredPostCodeViewTest.scala
+++ b/test/views/reenrolment/RegisteredPostCodeViewTest.scala
@@ -14,25 +14,26 @@
  * limitations under the License.
  */
 
-package views
+package views.reenrolment
 
-import forms.AwrsRegisteredPostcodeForm.awrsRegisteredPostcodeForm
+import forms.reenrolment.RegisteredPostcodeForm.awrsRegisteredPostcodeForm
 import play.twirl.api.HtmlFormat
-import views.html.awrs_registered_postcode
+import views.ViewTestFixture
+import views.html.reenrolment.awrs_registered_postcode
 
-class AwrsRegisteredPostCodeViewTest extends ViewTestFixture {
+class RegisteredPostCodeViewTest extends ViewTestFixture {
 
-  val view: awrs_registered_postcode = app.injector.instanceOf[views.html.awrs_registered_postcode]
+  val view: awrs_registered_postcode = app.injector.instanceOf[views.html.reenrolment.awrs_registered_postcode]
   override val htmlContent: HtmlFormat.Appendable = view.apply(awrsRegisteredPostcodeForm.form)(fakeRequest, messages, mockAppConfig)
 
-  "awrs registered postcode page" should {
+  "awrs registered postcode page" must {
     "render the correct content" in {
-      heading mustBe "Enter the postcode you registered with Alcohol Wholesaler Registration Scheme (AWRS)"
-      buttonText mustBe "Continue"
-      input_field_label mustBe "Enter the postcode you registered with Alcohol Wholesaler Registration Scheme (AWRS)"
+      heading mustBe messages("awrs.reenrolment.registered_postcode.title")
+      buttonText mustBe messages("awrs.generic.continue")
+      input_field_label mustBe messages("awrs.reenrolment.registered_postcode.heading")
       input_field must not be empty
-      back_link mustBe "Back"
-      back_link_href mustBe "/alcohol-wholesale-scheme/urn"
+      back_link mustBe messages("awrs.generic.back")
+      back_link_href mustBe controllers.reenrolment.routes.RegisteredUrnController.showArwsUrnPage.url
     }
   }
 }

--- a/test/views/reenrolment/RegisteredPostCodeViewTest.scala
+++ b/test/views/reenrolment/RegisteredPostCodeViewTest.scala
@@ -28,6 +28,7 @@ class RegisteredPostCodeViewTest extends ViewTestFixture {
 
   "awrs registered postcode page" must {
     "render the correct content" in {
+
       heading mustBe messages("awrs.reenrolment.registered_postcode.title")
       buttonText mustBe messages("awrs.generic.continue")
       input_field_label mustBe messages("awrs.reenrolment.registered_postcode.heading")

--- a/test/views/reenrolment/RegisteredUrnViewTest.scala
+++ b/test/views/reenrolment/RegisteredUrnViewTest.scala
@@ -30,14 +30,14 @@ class RegisteredUrnViewTest extends ViewTestFixture  {
   "Awrs Urn Template" must {
 
       "Display all fields correctly" in {
-        heading mustBe "What is your Alcohol Wholesaler Registration Scheme (AWRS) Unique Reference Number (URN)?"
 
-        document.select("label").text() mustBe "Your URN is 4 letters and 11 numbers, like XXAW00000123456. You can find it printed on the wholesaler or producer’s invoices. If you can’t find it, contact the wholesaler or producer for the URN."
-
+        heading mustBe messages("awrs.reenrolment.registered_urn.title")
+        document.select("label").text() mustBe messages("awrs.reenrolment.registered_urn.label")
         document.select("input").attr("id") mustBe "awrsUrn"
       }
 
     "contain a backlink pointing to the correct controller (haveYouRegistered)" in {
+
       val backlink = document.getElementById("back")
       backlink.attr("href") mustBe controllers.routes.HaveYouRegisteredController.showHaveYouRegisteredPage.url
     }

--- a/test/views/reenrolment/RegisteredUrnViewTest.scala
+++ b/test/views/reenrolment/RegisteredUrnViewTest.scala
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package views
+package views.reenrolment
 
-import forms.AwrsEnrolmentUrnForm.awrsEnrolmentUrnForm
+import forms.reenrolment.RegisteredUrnForm.awrsEnrolmentUrnForm
 import play.twirl.api.HtmlFormat
-import views.html.awrs_urn
+import views.ViewTestFixture
+import views.html.reenrolment.awrs_registered_urn
 
-class AwrsUrnViewTest extends ViewTestFixture  {
+class RegisteredUrnViewTest extends ViewTestFixture  {
 
-  val template: awrs_urn = app.injector.instanceOf[views.html.awrs_urn]
+  val template: awrs_registered_urn = app.injector.instanceOf[views.html.reenrolment.awrs_registered_urn]
 
   override val htmlContent: HtmlFormat.Appendable = template.apply(awrsEnrolmentUrnForm.form)(fakeRequest, messages, mockAppConfig)
 

--- a/test/views/reenrolment/RegisteredUtrCTViewTest.scala
+++ b/test/views/reenrolment/RegisteredUtrCTViewTest.scala
@@ -31,10 +31,9 @@ class RegisteredUtrCTViewTest extends ViewTestFixture {
   "Awrs Utr Template" must {
 
     "Display all fields correctly for IR-CT Tax Enrolment" in {
-      heading mustBe "Enter your Corporation Tax Unique Taxpayer Reference (UTR)"
 
-      document.select("label").text() mustBe "Your Unique Taxpayer Reference (UTR) is 10 or 13 digits long. You can find it in your Personal Tax Account, the HMRC app, or on tax returns and other letters about Corporation Tax. It might be called ‘reference’, ‘UTR’, or ‘official use’."
-
+      heading mustBe messages("awrs.reenrolment.registered_utr.title.ct")
+      document.select("label").text() mustBe messages("awrs.reenrolment.registered_utr.label")
       document.select("input").attr("id") mustBe "utr"
     }
   }

--- a/test/views/reenrolment/RegisteredUtrCTViewTest.scala
+++ b/test/views/reenrolment/RegisteredUtrCTViewTest.scala
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package views
+package views.reenrolment
 
-import forms.AwrsEnrolmentUtrForm.awrsEnrolmentUtrForm
+import forms.reenrolment.RegisteredUtrForm.awrsEnrolmentUtrForm
 import play.twirl.api.HtmlFormat
-import views.html.awrs_utr
+import views.ViewTestFixture
+import views.html.reenrolment.awrs_registered_utr
 
-class AwrsUtrCTViewTest extends ViewTestFixture {
+class RegisteredUtrCTViewTest extends ViewTestFixture {
 
-  val template: awrs_utr = app.injector.instanceOf[views.html.awrs_utr]
+  val template: awrs_registered_utr = app.injector.instanceOf[views.html.reenrolment.awrs_registered_utr]
   // indicating logged-in user has IR-CT enrolment
   val isSa = false
   override val htmlContent: HtmlFormat.Appendable = template.apply(awrsEnrolmentUtrForm.form, isSa)(fakeRequest, messages, mockAppConfig)

--- a/test/views/reenrolment/RegisteredUtrSAViewTest.scala
+++ b/test/views/reenrolment/RegisteredUtrSAViewTest.scala
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package views
+package views.reenrolment
 
-import forms.AwrsEnrolmentUtrForm.awrsEnrolmentUtrForm
+import forms.reenrolment.RegisteredUtrForm.awrsEnrolmentUtrForm
 import play.twirl.api.HtmlFormat
-import views.html.awrs_utr
+import views.ViewTestFixture
+import views.html.reenrolment.awrs_registered_utr
 
-class AwrsUtrSAViewTest extends ViewTestFixture  {
+class RegisteredUtrSAViewTest extends ViewTestFixture  {
 
-  val template: awrs_utr = app.injector.instanceOf[views.html.awrs_utr]
+  val template: awrs_registered_utr = app.injector.instanceOf[views.html.reenrolment.awrs_registered_utr]
   // indicating logged-in user has IR-SA enrolment
   val isSA = true
   override val htmlContent: HtmlFormat.Appendable = template.apply(awrsEnrolmentUtrForm.form, isSA)(fakeRequest, messages, mockAppConfig)

--- a/test/views/reenrolment/RegisteredUtrSAViewTest.scala
+++ b/test/views/reenrolment/RegisteredUtrSAViewTest.scala
@@ -31,10 +31,9 @@ class RegisteredUtrSAViewTest extends ViewTestFixture  {
   "Awrs Utr Template" must {
 
     "Display all fields correctly for IR-AS Tax Enrolment" in {
-      heading mustBe "Enter your Self Assessment Tax Unique Taxpayer Reference (UTR)"
 
-      document.select("label").text() mustBe "Your Unique Taxpayer Reference (UTR) is 10 or 13 digits long. You can find it in your Personal Tax Account, the HMRC app, or on tax returns and other letters about Corporation Tax. It might be called ‘reference’, ‘UTR’, or ‘official use’."
-
+      heading mustBe messages("awrs.reenrolment.registered_utr.title.sa")
+      document.select("label").text() mustBe messages("awrs.reenrolment.registered_utr.label")
       document.select("input").attr("id") mustBe "utr"
     }
   }

--- a/test/views/reenrolment/SuccessfulEnrolmentViewTest.scala
+++ b/test/views/reenrolment/SuccessfulEnrolmentViewTest.scala
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package views
+package views.reenrolment
 
 import play.twirl.api.HtmlFormat
-import views.html.awrs_successful_enrolment
+import views.ViewTestFixture
+import views.html.reenrolment.awrs_successful_enrolment
 
 class SuccessfulEnrolmentViewTest extends ViewTestFixture {
 
   val view: awrs_successful_enrolment =
-    app.injector.instanceOf[views.html.awrs_successful_enrolment]
+    app.injector.instanceOf[views.html.reenrolment.awrs_successful_enrolment]
   override val htmlContent: HtmlFormat.Appendable = view.apply()(fakeRequest, messages, mockAppConfig)
   "successful_enrolment page" should {
     "render the correct content" in {

--- a/test/views/reenrolment/SuccessfulEnrolmentViewTest.scala
+++ b/test/views/reenrolment/SuccessfulEnrolmentViewTest.scala
@@ -25,17 +25,21 @@ class SuccessfulEnrolmentViewTest extends ViewTestFixture {
   val view: awrs_successful_enrolment =
     app.injector.instanceOf[views.html.reenrolment.awrs_successful_enrolment]
   override val htmlContent: HtmlFormat.Appendable = view.apply()(fakeRequest, messages, mockAppConfig)
+
   "successful_enrolment page" should {
+
     "render the correct content" in {
-      heading mustBe "You have added your AWRS to your business tax account"
-      bodyText mustBe "You can now view and manage your AWRS registration in your business tax account. More detailed information can be found in the AWRS guidance (opens in a new tab)"
+      heading mustBe messages("awrs.reenrolment.successful_enrolment.title")
+      bodyText mustBe (
+        messages("awrs.reenrolment.successful_enrolment.p1") + " " +
+        messages("awrs.reenrolment.successful_enrolment.p2")
+        )
     }
 
-    "contain a button to access the Business Tax Account page" in{
+    "contain a button to access the Business Tax Account page" in {
+
       val link = document.getElementById("bta-redirect-button")
       link.attr("role") mustBe "button"
     }
-
   }
-
 }


### PR DESCRIPTION
This PR aims to homogenise the code a bit more, and separate the reenrolment feature into separate packages to increase code readability and stability.

Files are renamed and moved accordingly. Tests are adjusted, and and some refactorings / renamings are carried out.