### PR TITLE
Dl 17277 task list pattern

### DIFF
--- a/app/view_models/IndexViewModel.scala
+++ b/app/view_models/IndexViewModel.scala
@@ -27,7 +27,7 @@ sealed trait IndexStatus {
 
 case object SectionComplete extends IndexStatus {
   val messagesKey: String = "awrs.index_page.complete"
-  val cssClass: String = "govuk-tag govuk-tag--turquoise"
+  val cssClass: String = "govuk-!-font-weight-regular"
 }
 
 case object SectionIncomplete extends IndexStatus {

--- a/app/views/awrs_index.scala.html
+++ b/app/views/awrs_index.scala.html
@@ -113,50 +113,26 @@
 
             <p class="govuk-body" id="applicationInfo">@messages("awrs.index_page.topText")</p>
 
-                <table class="govuk-table" id="index-table">
-                    <caption class="govuk-visually-hidden">@pageHeading</caption>
-                    <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th scope="col" id="section-text" class="govuk-table__header">@messages("awrs.index_page.section_text")</th>
-                            <th scope="col" id="status-text" class="govuk-table__header govuk-!-width-one-quarter">@messages("awrs.index_page.status_text")</th>
-                            <th scope="col" id="action-text" class="govuk-table__header print-hidden">@messages("awrs.index_page.action_text")</th>
-                        </tr>
-                    </thead>
-                    <tbody class="govuk-table__body">
-                    @indexStatusModel.sectionModels.zipWithIndex.map { case (i, id) =>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell" id="@i.id">
-                                @{id+1}. @messages(i.text)
-                                @i.size match {
-                                    case Some(size) => {&nbsp;(@size)<span class="govuk-visually-hidden">entries</span>}
-                                    case _ => {}
-                                }
-                        </td>
-                        <td class="govuk-table__cell awrs-status">
-                            <strong class="govuk-tag @{i.status.cssClass}" id="@{i.id + "_status"}">
+            <ul class="govuk-task-list">
+                @indexStatusModel.sectionModels.zipWithIndex.map { case (i, id) =>
+                    <li class="govuk-task-list__item govuk-task-list__item--with-link">
+                        <div class="govuk-task-list__name-and-hint">
+                        <a class="govuk-link govuk-task-list__link" href="@i.href" aria-describedby="@{i.id}_status" id="@i.id">
+                            @messages(i.text)
+                            @i.size match {
+                                case Some(size) => {&nbsp;(@size)<span class="govuk-visually-hidden">entries</span>}
+                                case _ => {}
+                            }
+                        </a>
+                        </div>
+                        <div class="govuk-task-list__status" id="@{i.id}_status">
+                            <strong class="@{i.status.cssClass}">
                                 @messages(i.status.messagesKey)
                             </strong>
-                        </td>
-                        <td class="govuk-table__cell">
-                            <a class="govuk-link govuk-body" href="@i.href">
-                                @Html(messages({i.status + "_link" +
-                                        {
-                                            someStatus match {
-                                                case Some(subStatus :SubscriptionStatusType) =>
-                                                    subStatus.formBundleStatus match {
-                                                        case Rejected | RejectedUnderReviewOrAppeal | RevokedUnderReviewOrAppeal=> "_rejected"
-                                                        case _        => ""
-                                                    }
-                                                case _ => ""
-                                            }
-                                        }
-                                }, messages(i.text) + messages("awrs.index_page.status_description_text") + " " + messages(i.status.messagesKey) + ", "))
-                            </a>
-                        </td>
-                    </tr>
-                    }
-                    </tbody>
-                </table>
+                        </div>
+                    </li>
+                }
+            </ul>
 
             @awrsRef match {
                 case Some(_) => {

--- a/conf/messages
+++ b/conf/messages
@@ -370,10 +370,10 @@ awrs.index_page.submit_changes=Submit changes
 awrs.index_page.de_registration_link=Cancel registration
 awrs.index_page.withdraw_link=Withdraw application
 awrs.index_page.topText=Each section is saved as you progress. Once you start you have 28 days to complete the application before it is deleted.
-awrs.index_page.not_started=NOT STARTED
-awrs.index_page.incomplete=INCOMPLETE
-awrs.index_page.complete=COMPLETED
-awrs.index_page.edited=EDITED
+awrs.index_page.not_started=Not Started
+awrs.index_page.incomplete=Incomplete
+awrs.index_page.complete=Completed
+awrs.index_page.edited=Edited
 awrs.index_page.awrs_ref=AWRS reference number
 
 # Dynamically created - DO NOT DELETE

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -28,7 +28,7 @@ private object AppDependencies {
     "uk.gov.hmrc"                   %% "bootstrap-frontend-play-30"  % bootstrapPlayVersion,
     "uk.gov.hmrc"                   %% "play-partials-play-30"       % "10.1.0", // includes code for retrieving partials, e.g. the Help with this page form
     "com.yahoo.platform.yui"        %  "yuicompressor"               % "2.4.8",
-    "uk.gov.hmrc"                   %% "play-frontend-hmrc-play-30"  % "12.8.0",
+    "uk.gov.hmrc"                   %% "play-frontend-hmrc-play-30"  % "12.15.0",
     "commons-codec"                 %  "commons-codec"               % "1.19.0",
     "com.googlecode.htmlcompressor" %  "htmlcompressor"              % "1.5.2"
   )


### PR DESCRIPTION
This PR updates the non-compliant pattern used on the Application summary page. The following issue was raised as part of the DAC retest:

The ‘Application summary’ page presents users with a table of tasks that users may need to complete over several sessions. However, this does not conform with the [Task list pages – GOV.UK Design System](https://design-system.service.gov.uk/components/task-list/) guidelines and some screen reader users find table content difficult
to navigate.

<img width="616" height="435" alt="Screenshot 2025-09-05 at 11 42 47" src="https://github.com/user-attachments/assets/e255be7f-b180-4426-85fa-dee69ae20f0a" />

**Screen reader comments:**
“I discovered that the task list content was contained within a table. This made it more time consuming to move around the content to locate what needed to be completed. After further investigation I found that the items appeared in the correct order when browsing in context making the table unnecessary. Removing the table and introducing each section with a heading will provide an easier experience for screen reader users. Please note that
the task list pattern is presently experimental within the Design System. The issue occurs
with JAWS, NVDA and VoiceOver for iPhone.”

**Solution:**
Consider presenting tasks in a list format as is demonstrated by the coded example of a task list page in the GOV.UK Prototype Kit. This may help screen reader users to navigate and understand page content more efficiently.

This PR implements the approved TaskList pattern: https://design-system.service.gov.uk/components/task-list/

<img width="701" height="952" alt="Screenshot 2025-09-17 at 11 21 37" src="https://github.com/user-attachments/assets/1e29bddd-bc2c-4c84-add1-e5455523fa62" />

Given the user does need need to complete the tasks in a specific order, the numbers have been dropped.
