### PR TITLE
DL-17812 - update page title on confirmation page

### DIFF
--- a/app/views/awrs_application_confirmation.scala.html
+++ b/app/views/awrs_application_confirmation.scala.html
@@ -26,7 +26,7 @@
 @(submissionDate: String, isNewBusiness : Boolean, printFriendly: Boolean = false, selfHeal: Boolean = false)(implicit request: Request[AnyContent], messages: Messages, applicationConfig: ApplicationConfig)
 
 @govWrapper = {
-    @awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.confirmation.title")), userLoggedIn = true){
+    @awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.confirmation.title", request.session.get("businessName").getOrElse(""))), userLoggedIn = true){
 
                 @confirmationHelper(
                     "awrs.confirmation.description",

--- a/app/views/awrs_application_update_confirmation.scala.html
+++ b/app/views/awrs_application_update_confirmation.scala.html
@@ -29,7 +29,7 @@
 @awrsRef = @{sessionUtil(request).getSessionAwrsRefNo.fold("")(x => x)}
 
 @govWrapper = {
-    @awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.confirmation.title")), userLoggedIn = true){
+    @awrsMain(title = messages("awrs.generic.tab.title", messages("awrs.update.confirmation.title", request.session.get("businessName").getOrElse(""))), userLoggedIn = true){
                 @confirmationHelper(
                     "awrs.update.confirmation.description",
                     "awrs.update.confirmation.description_1",

--- a/conf/messages
+++ b/conf/messages
@@ -751,7 +751,7 @@ awrs.application_declaration.error.confirmation_empty=You must confirm the appli
 # Confirmation Page
 #============================================================
 awrs.confirmation.button=Confirm and continue
-awrs.confirmation.title=Confirmation
+awrs.confirmation.title=Your application for {0}
 awrs.confirmation.description=Your application for
 awrs.confirmation.description_1=has been received on
 awrs.confirmation.information=What happens next
@@ -771,6 +771,7 @@ awrs.confirmation.finish=Finish and sign out
 
 # Update Confirmation Page
 #============================================================
+awrs.update.confirmation.title=Your amendment for {0}
 awrs.update.confirmation.description=Your amendment for
 awrs.update.confirmation.description_1=has been received on
 awrs.update.confirmation.information_what_next_0=Continue trading as normal while we review and check your amended application (reference {0}).


### PR DESCRIPTION
Updates the page title to match the H1 - this is important for usability as some users would expect the page title and main heading to reflect one another, as both briefly introduce the content or purpose of the page content.